### PR TITLE
Proper checking of subscription status

### DIFF
--- a/steps/redhat.py
+++ b/steps/redhat.py
@@ -46,7 +46,8 @@ def step_impl(context, host):
     r = context.remote_cmd("command",
                            host,
                            module_args="subscription-manager status")
-    assert r
+    for i in r:
+        assert 'Status: Current' in i['stdout']
 
 @then(u'"{total}" entitlement is consumed on "{host}"')
 def step_impl(context, total, host):


### PR DESCRIPTION
When a system is unregistered and **subscription-manger status** is run, the command returns **0**, but the output indicates the subscription is not OK:

```
# subscription-manager list

+-------------------------------------------+
    Installed Product Status
+-------------------------------------------+
Product Name:   Red Hat Enterprise Linux Server
Product ID:     69
Version:        7.0
Arch:           x86_64
Status:         Unknown
Status Details: 
Starts:         
Ends:           

Product Name:   Red Hat Enterprise Linux Atomic Host Beta
Product ID:     272
Version:        7-Beta
Arch:           x86_64
Status:         Unknown
Status Details: 
Starts:         
Ends:           

# subscription-manager status
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Unknown

# echo $?
0
```

This change introduces the proper checking for a **Current** subscription.

```
# subscription-manager list

+-------------------------------------------+
    Installed Product Status
+-------------------------------------------+
Product Name:   Red Hat Enterprise Linux Server
Product ID:     69
Version:        7.0
Arch:           x86_64
Status:         Subscribed
Status Details: 
Starts:         04/24/2013
Ends:           01/01/2022

Product Name:   Red Hat Enterprise Linux Atomic Host Beta
Product ID:     272
Version:        7-Beta
Arch:           x86_64
Status:         Subscribed
Status Details: 
Starts:         04/24/2013
Ends:           01/01/2022

# subscription-manager status
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Current

# echo $?
0
```
