### PR TITLE
Inventory#15

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -107,11 +107,9 @@ def before_all(context):
 
         if context.inventory == "dynamic":
             # use custom dynamic hosts script
-            print "USING DYNAMIC"
             inventory = ansible.inventory.Inventory(config.get('ansible', 'dynamic_inventory_script'))
         else:
             # default to static file
-            print "USING STATIC"
             inventory = ansible.inventory.Inventory(config.get('ansible', 'inventory'))
 
         # the user can specify to not use 'sudo' per command or use the config file value

--- a/environment.py
+++ b/environment.py
@@ -105,11 +105,13 @@ def before_all(context):
 
         inventory = None
 
-        if context.inventory == "dyanmic":
+        if context.inventory == "dynamic":
             # use custom dynamic hosts script
+            print "USING DYNAMIC"
             inventory = ansible.inventory.Inventory(config.get('ansible', 'dynamic_inventory_script'))
         else:
             # default to static file
+            print "USING STATIC"
             inventory = ansible.inventory.Inventory(config.get('ansible', 'inventory'))
 
         # the user can specify to not use 'sudo' per command or use the config file value

--- a/environment.py
+++ b/environment.py
@@ -105,13 +105,9 @@ def before_all(context):
 
         inventory = None
 
-        if hasattr(context, 'dynamic_hosts'):
-            host = context.dynamic_hosts
+        if context.inventory == "dyanmic":
             # use custom dynamic hosts script
             inventory = ansible.inventory.Inventory(config.get('ansible', 'dynamic_inventory_script'))
-        elif hasattr(context, 'static_host'):
-            # use static ansible inventory file
-            inventory = ansible.inventory.Inventory(config.get('ansible', 'inventory'))
         else:
             # default to static file
             inventory = ansible.inventory.Inventory(config.get('ansible', 'inventory'))
@@ -121,6 +117,14 @@ def before_all(context):
             sudo = sudo
         else:
             sudo = config.get('ansible', 'sudo')
+
+        # check value of host. if host is not None, we assume the user has
+        # supplied a host arg to remote_cmd(). otherwise, it is passed
+        # along in the context object.
+        if host is not None:
+            host = host
+        else:
+            host = context.target_host
 
         # the 'context' object can basically hold whatever we want.
         # if we stash the result from Ansible, we can inspect it or log it

--- a/steps/common.py
+++ b/steps/common.py
@@ -4,12 +4,12 @@ from behave import *
 
 @given(u'"{host}" hosts from dynamic inventory')
 def step_impl(context, host):
-    context.dynamic_hosts = host
+    context.inventory = "dynamic"
     context.target_host = host 
 
 @given(u'"{host}" host from static inventory')
 def step_impl(context, host):
-    context.static_host = host
+    context.inventory = "static"
     context.target_host = host 
 
 @given(u'"{rpm}" is already installed on "{host}"')
@@ -81,7 +81,7 @@ def step(context, host):
     '''Verify we can ping the host
 
     host: a host from the ansible inventory file'''
-    assert context.remote_cmd('ping', host)
+    assert context.remote_cmd(cmd='ping')
 
 @given('run command "{cmd}" on "{host}"')
 @when('run command "{cmd}" on "{host}"')

--- a/steps/common.py
+++ b/steps/common.py
@@ -81,7 +81,7 @@ def step(context, host):
     '''Verify we can ping the host
 
     host: a host from the ansible inventory file'''
-    assert context.remote_cmd(cmd='ping')
+    assert context.remote_cmd('ping', host)
 
 @given('run command "{cmd}" on "{host}"')
 @when('run command "{cmd}" on "{host}"')

--- a/steps/common.py
+++ b/steps/common.py
@@ -7,7 +7,7 @@ def step_impl(context, host):
     context.inventory = "dynamic"
     context.target_host = host 
 
-@given(u'"{host}" host from static inventory')
+@given(u'"{host}" hosts from static inventory')
 def step_impl(context, host):
     context.inventory = "static"
     context.target_host = host 


### PR DESCRIPTION
I believe these changes will address issue #15 and clean up how dynamic/static inventory is handled.

I tested this using a `resources.json` file in single-host format and multi-host format that was parsed by the dynamic inventory script.  Additionally, I also tested using an INI style Ansible inventory (i.e. static inventory) with both single and multi-hosts.

The basic test feature file looked like this:

``` gherkin
Feature: ostree host scratch test
    Scratch space for proving out tests

Background: Atomic hosts are discovered
      Given "all" hosts from static inventory

  Scenario: 1. Host provisioned and subscribed
      Given "all" host
```

...where the Background was changed between dynamic/static inventory.

For the test I modified the step implementation of Scenario 1, so that the host wouldn't be passed to `remote_cmd()`.  And I tested with the host being explicitly passed, too.

I ran some other existing steps, too.  No issues that I could see.

Would love to have folks clone this branch and test their own feature files with it.
