### PR TITLE
New feature file for upgrade/rollback

### DIFF
--- a/features/ostree/sanity_new_qcow.feature
+++ b/features/ostree/sanity_new_qcow.feature
@@ -12,9 +12,9 @@ Background: Atomic hosts are discovered
         and current atomic version should match the original atomic version
 
   Scenario: 2. Host unprovisioned and 'atomic host rollback' is used
-      Given there is "1" atomic host tree deployment
+      Given there is "1" atomic host tree deployed
        Then atomic host rollback should return a deployment error
-        and there is "1" atomic host tree deployment
+        and there is "1" atomic host tree deployed
 
   Scenario: 3. Host provisioned and subscribed
        When "all" host is auto-subscribed to "stage"
@@ -22,14 +22,14 @@ Background: Atomic hosts are discovered
         and "1" entitlement is consumed on "all"
 
   Scenario: 4. 'atomic host upgrade' is successful when no upgrade available
-      Given there is "1" atomic host tree deployment
+      Given there is "1" atomic host tree deployed
        Then atomic host upgrade reports no upgrade available
-        and there is "1" atomic host tree deployment
+        and there is "1" atomic host tree deployed
 
   Scenario: 5. 'atomic host rollback' reports error about single deployment
-      Given there is "1" atomic host tree deployment
+      Given there is "1" atomic host tree deployed
        Then atomic host rollback should return a deployment error
-        and there is "1" atomic host tree deployment
+        and there is "1" atomic host tree deployed
 
   Scenario: 6. Unregister
        Then "all" host is unsubscribed and unregistered

--- a/features/ostree/sanity_new_tree.feature
+++ b/features/ostree/sanity_new_tree.feature
@@ -1,0 +1,27 @@
+Feature: Atomic host sanity test for new QCOW images
+    Describes the basic 'atomic host' command functionality for a fresh
+    QCOW image install.
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from static inventory
+        and "all" host
+
+  Scenario: 3. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 4. 'atomic host upgrade' is successful
+      Given there is "1" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 5. Reboot into the new deployment
+     Given: there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+      Then: wait "20" seconds for "all" to reboot
+
+
+  Scenario: 6. Unregister
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"

--- a/features/ostree/sanity_new_tree.feature
+++ b/features/ostree/sanity_new_tree.feature
@@ -1,6 +1,5 @@
-Feature: Atomic host sanity test for new QCOW images
-    Describes the basic 'atomic host' command functionality for a fresh
-    QCOW image install.
+Feature: Atomic host sanity test for new upgrade tree
+    Describes tests for upgrade/rollback to/from new ostree
 
 Background: Atomic hosts are discovered
       Given "all" hosts from static inventory
@@ -17,10 +16,17 @@ Background: Atomic hosts are discovered
        Then there is "2" atomic host tree deployed
 
   Scenario: 5. Reboot into the new deployment
-     Given: there is "2" atomic host tree deployed
+      Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
-      Then: wait "20" seconds for "all" to reboot
+       When wait "20" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
 
+  Scenario: 6. Rollback to the original deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When atomic host rollback is successful
+        and wait "20" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
 
   Scenario: 6. Unregister
        Then "all" host is unsubscribed and unregistered

--- a/features/ostree/sanity_new_tree.feature
+++ b/features/ostree/sanity_new_tree.feature
@@ -2,7 +2,7 @@ Feature: Atomic host sanity test for new upgrade tree
     Describes tests for upgrade/rollback to/from new ostree
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from static inventory
+      Given "all" hosts from dynamic inventory
         and "all" host
 
   Scenario: 3. Host provisioned and subscribed


### PR DESCRIPTION
Mostly changes for testing upgrade/rollback with a new tree.  Ran through both feature files locally and via Jenkins.
- `features/ostree/sanity_new_qcow.feature`
  - Changed the natural language to make more sense
- `features/ostree/sanity_new_tree.feature`
  - New feature file
- `steps/ostree.py`
  - Fixed a bug in the regex
  - Updating the steps for counting deployments to use different language
  - Added steps for supporting upgrade/rollback
