### PR TITLE
Fixing print statements for behave 1.2.5

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -1,4 +1,5 @@
 '''Magically loaded by behave defining helper methods and other things'''
+from __future__ import print_function
 
 # define the necessary logging features to write messages to a file
 import logging
@@ -79,7 +80,7 @@ def before_all(context):
                          headers=post_headers,
                          data=payload)
         if result.raise_for_status():
-            print 'Status %s: %s' % (result.status_code, result.json()['error'])
+            print('Status %s: %s' % (result.status_code, result.json()['error']))
             return False
         if app is "satellite":
             if payload is None and method is None:
@@ -87,7 +88,7 @@ def before_all(context):
             else:
                 return result.json()
         elif app is "openshiftv2":
-            print result.json()
+            print(result.json())
             return result.json()
 
     context.api = api
@@ -143,10 +144,10 @@ def before_all(context):
 
         # TODO support lists of hosts
         if context.result['dark']:
-            print context.result['dark']
+            print(context.result['dark'])
             return False
         elif not context.result['contacted']:
-            print context.result
+            print(context.result)
             return False
         else:
             values = []


### PR DESCRIPTION
Upon upgrading to behave 1.2.5, I started getting these kinds of errors:

```
Exception SyntaxError: invalid syntax (environment.py, line 82)
Traceback (most recent call last):
  File "/usr/bin/behave", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/site-packages/behave/__main__.py", line 109, in main
    failed = runner.run()
  File "/usr/lib/python2.7/site-packages/behave/runner.py", line 672, in run
    return self.run_with_paths()
  File "/usr/lib/python2.7/site-packages/behave/runner.py", line 677, in run_with_paths
    self.load_hooks()
  File "/usr/lib/python2.7/site-packages/behave/runner.py", line 631, in load_hooks
    exec_file(hooks_path, self.hooks)
  File "/usr/lib/python2.7/site-packages/behave/runner.py", line 303, in exec_file
    code = compile(f.read(), filename2, 'exec')
  File "environment.py", line 82
    print 'Status %s: %s' % (result.status_code, result.json()['error'])
                        ^
SyntaxError: invalid syntax
```

I found the following issue: 

https://github.com/behave/behave/issues/287 

...which accurately described the problem.

And the solution:

https://github.com/behave/behave/issues/287#issuecomment-72948839
