### PR TITLE
Remove 'sudo' per command

### DIFF
--- a/config/uat.cfg.sample
+++ b/config/uat.cfg.sample
@@ -1,6 +1,5 @@
 [ansible]
 inventory = config/ansible_inventory
-sudo = True
 dynamic_inventory_script = config/central_ci_dynamic_hosts.py
 
 [redhat-prod]

--- a/environment.py
+++ b/environment.py
@@ -93,13 +93,12 @@ def before_all(context):
 
     context.api = api
 
-    def remote_cmd(cmd, host=None, sudo=None, ignore_rc=False, **kwargs):
+    def remote_cmd(cmd, host=None, ignore_rc=False, **kwargs):
         '''Interface to run a command on a remote host using Ansible modules
 
         host: name of host of remote target system in ansible inventory file
               or environment variable
         cmd: an Ansible module
-        sudo: control if the command should use sudo
         ignore_rc: occasionally the command is expected to fail.  Set this to
                    True so that the output is retained and can be used
         module_args: module args in the form of "key1=value1 key2=value2"
@@ -116,12 +115,6 @@ def before_all(context):
             # default to static file
             inventory = ansible.inventory.Inventory(config.get('ansible', 'inventory'))
 
-        # the user can specify to not use 'sudo' per command or use the config file value
-        if sudo is not None:
-            sudo = sudo
-        else:
-            sudo = config.get('ansible', 'sudo')
-
         # check value of host. if host is not None, we assume the user has
         # supplied a host arg to remote_cmd(). otherwise, it is passed
         # along in the context object.
@@ -137,7 +130,6 @@ def before_all(context):
                  module_name=cmd,
                  inventory=inventory,
                  pattern=host,
-                 sudo=sudo,
                  #remote_user=remote_user,
                  **kwargs
         ).run()

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -8,7 +8,6 @@ from behave import *
 
 def get_atomic_version(context):
     version_result = context.remote_cmd(cmd='command',
-                                        sudo=False,
                                         module_args='atomic host status')
 
     assert version_result, "Error running 'atomic host status'"
@@ -66,8 +65,7 @@ def step_impl(context, seconds, host):
 
     time.sleep(float(seconds))
     ping_result = context.remote_cmd(cmd='ping',
-                                     host=host,
-                                     sudo=False)
+                                     host=host)
     assert ping_result, "Unable to ping host after reboot"
 
 
@@ -113,7 +111,6 @@ def step_impl(context):
 
     upgrade_result = context.remote_cmd(cmd='command',
                                         ignore_rc=True,
-                                        sudo=True,
                                         module_args='atomic host upgrade')
 
     for r in upgrade_result:
@@ -142,7 +139,6 @@ def step_impl(context):
 
     rollback_result = context.remote_cmd(cmd='command',
                                          ignore_rc=True,
-                                         sudo=True,
                                          module_args='atomic host rollback')
 
     for r in rollback_result:
@@ -156,7 +152,6 @@ def step_impl(context):
     expected_msg = "No upgrade available."
 
     upgrade_result = context.remote_cmd(cmd='command',
-                                        sudo=True,
                                         module_args='atomic host upgrade')
 
     assert upgrade_result, "Error while running 'atomic host upgrade'"
@@ -187,7 +182,6 @@ def step_impl(context):
 @when(u'atomic host upgrade is successful')
 def step_impl(context):
     upgrade_result = context.remote_cmd(cmd='command',
-                                        sudo=True,
                                         module_args='atomic host upgrade')
 
     assert upgrade_result, "Error performing 'atomic host upgrade"
@@ -206,7 +200,6 @@ def step_impl(context):
 @when(u'atomic host rollback is successful')
 def step_impl(context):
     rollback_result = context.remote_cmd(cmd='command',
-                                         sudo=True,
                                          module_args='atomic host rollback')
 
     assert rollback_result, "Error while running 'atomic host rollback'"
@@ -223,7 +216,6 @@ def step_impl(context):
 @when(u'the data collection script is run')
 def step_impl(context):
     run_result = context.remote_cmd(cmd='command',
-                                    sudo=True,
                                     module_args='/usr/local/bin/atomic_smoketest.sh')
 
     assert run_result, "Error while running data collection script"


### PR DESCRIPTION
The ansible runner API has removed controlling the sudo boolean per
command. Sudo is only available via the inventory file. This commit
removes any reference to sudo on a per-command level.

See
https://github.com/ansible/ansible/commit/5f6db0e16477749c1bccf472150132ca06c50b3b#diff-af869caf5f6f46706dbf35970e39c686

NOTE: if you want to enable this feature we may be able to update
the inventory object.
