### PR TITLE
if the service is already started and enabled, make sure this step is not failed

### DIFF
--- a/steps/common.py
+++ b/steps/common.py
@@ -72,7 +72,7 @@ def step_impl(context, unit, host):
                            module_args='name=%s state=running enabled=yes' % unit)
     if r:
         for i in r:
-            assert i['changed'] is True
+            assert i['state'] == 'started' and i['enabled'] is True
     else:
         assert False
 


### PR DESCRIPTION
Currently, it's always failed at this step if the service is already started and enabled, make sure it's not failed.
