### PR TITLE
Feature/steps files for interrupting upgrades

### DIFF
--- a/features/rhelah/upgrade_multi_interrupt.feature
+++ b/features/rhelah/upgrade_multi_interrupt.feature
@@ -1,0 +1,37 @@
+Feature:  Verifies that the 'atomic host upgrade' can be interrupted
+          multiple times without error
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        and "all" hosts can be pinged
+
+  Scenario: 1. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 2. Start upgrade process and interrupt 10 times
+      Given the upgrade interrupt script is present
+        and the original atomic version has been recorded
+       When the upgrade interrupt script is run "10" times
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 3. Reboot the system
+      Given the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 4. Complete the upgrade
+      Given there is "1" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 5. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 6. Unregister
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"

--- a/features/rhelah/upgrade_single_interrupt.feature
+++ b/features/rhelah/upgrade_single_interrupt.feature
@@ -1,0 +1,37 @@
+Feature:  Verifies that the 'atomic host upgrade' can be interrupted
+          a single time without error
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        and "all" hosts can be pinged
+
+  Scenario: 1. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 2. Start upgrade process and interrupt 1 times
+      Given the upgrade interrupt script is present
+        and the original atomic version has been recorded
+       When the upgrade interrupt script is run "1" times
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 3. Reboot the system
+      Given the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 4. Complete the upgrade
+      Given there is "1" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 5. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 6. Unregister
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -263,3 +263,19 @@ def step_impl(context):
                                       module_args='src=/var/qe/atomic_smoke_failed dest=%s/ flat=yes' % jenkins_ws)
 
     assert fetch_result, "Error retrieving the data collection failure file"
+
+
+@given(u'the upgrade interrupt script is present')
+def step_impl(context):
+    stat_result = context.remote_cmd(cmd='stat',
+                                     module_args='path=/usr/local/bin/atomic_upgrade_interrupt.sh')
+
+    assert stat_result, "The atomic upgrade interrupt script is missing"
+
+
+@when(u'the upgrade interrupt script is run "{num}" times')
+def step_impl(context, num):
+    int_result = context.remote_cmd(cmd='command',
+                                    module_args='/usr/local/bin/atomic_upgrade_interrupt.sh %s' % num)
+
+    assert int_result, "Error while running atomic upgrade interrupt script"


### PR DESCRIPTION
This change includes two feature files which validate that the 'atomic
host upgrade' process can be interrupted without error.  The case of a
single interrupt and multiple interrupts are covered.

Additionally, the step file has been updated to include support for
these feature tests.

Signed-off-by: Micah Abbott miabbott@redhat.com
