### PR TITLE
New set of sanity tests for cloud-init RH subscrition-manager plugin

### DIFF
--- a/features/subman_ok.feature
+++ b/features/subman_ok.feature
@@ -1,0 +1,23 @@
+Feature: Atomic cloud-init subscription-manager plugin test
+    Tests whether subscription-manager uses provided credentials to register to the CDN, attaches pools, enables/disables provided repoids
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        and "all" host
+
+  Scenario: 0. subscription-manager plugin has been run successfully
+       Given cloud-init on "all" host is running
+       Then wait for rh_subscription_manager plugin to finish
+        and check if it completed successfully
+
+  Scenario: 1. subscription-manager registers successfully
+       Given cloud-init on "all" host is running
+       Then check if the subscription-manager successfully registered
+
+  Scenario: 2. subscription-manager plugin attaches existing pools
+       Given cloud-init on "all" host is running
+       Then check if it successfully attached defined pools
+
+  Scenario: 3. subscription-manager plugin enables existing listed repoids
+       Given cloud-init on "all" host is running
+       Then check if the existing listed repoids were enabled

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -279,3 +279,41 @@ def step_impl(context, num):
                                     module_args='/usr/local/bin/atomic_upgrade_interrupt.sh %s' % num)
 
     assert int_result, "Error while running atomic upgrade interrupt script"
+
+@given(u'cloud-init on "{host}" host is running')
+def step_imp(context,host):
+	cloudinit_is_active = context.remote_cmd(cmd='command',
+					host=host,
+					module_args='systemctl is-active cloud-init')
+	assert cloudinit_is_active, "The cloud-init service is not running"
+
+@then(u'wait for rh_subscription_manager plugin to finish')
+def step_impl(context):
+	cloudinit_completed = context.remote_cmd(cmd='wait_for',
+					module_args = 'path=/var/log/cloud-init.log search_regex=complete')
+
+	assert cloudinit_completed[0].has_key('failed') == False, "The cloud-init service did not complete"
+
+@then(u'check if it completed successfully')
+def step_impl(context):
+	cloudinit_result = context.remote_cmd(cmd='shell',
+					module_args='grep cc_rh_subscription.py /var/log/cloud-init.log | tail -n1 | cut -d ":" -f4 | sed "s/^ //"')[0]['stdout']
+	assert cloudinit_result == 'rh_subscription plugin completed successfully', 'rh_subscription plugin failed'
+
+@then(u'check if the subscription-manager successfully registered')
+def step_impl(context):
+	register_result =  context.remote_cmd(cmd='shell',
+                    module_args='grep cc_rh_subscription.py /var/log/cloud-init.log | grep Regist | cut -d ":" -f4 | sed -e "s/^ //" -e "s/ [-a-f0-9]\+//"')[0]['stdout']
+	assert register_result == 'Registered successfully with ID', "subscription-manager did not register successfully"
+
+@then(u'check if it successfully attached defined pools')
+def step_impl(context):
+	pools_attached = context.remote_cmd(cmd='shell',
+					module_args='grep cc_rh_subscription.py /var/log/cloud-init.log | grep pools | cut -d ":" -f5 | sed "s/^ //"')[0]['stdout']
+	assert pools_attached == '8a85f9823e3d5e43013e3ddd4e9509c4', "Configured pools weren't attached"
+
+@then(u'check if the existing listed repoids were enabled')
+def step_impl(context):
+	repoids_enabled = context.remote_cmd(cmd='shell',
+                    module_args='grep cc_rh_subscription.py /var/log/cloud-init.log | grep "Enabled the following repos" | cut -d ":" -f5 | sed "s/^ //"')[0]['stdout']
+	assert repoids_enabled == 'rhel-7-server-optional-beta-rpms, rhel-7-server-beta-debug-rpms', "Configured repoids weren't enabled"


### PR DESCRIPTION
Hi Aaron,

I have created a new set of tests for sanity testing of RH subscription-manager plugin to the cloud-init. Please review the patch and if possible merge it to the upstream.

Thanks,
Ladislav
