### PR TITLE
print ansible output when the step is failed

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -148,6 +148,7 @@ def before_all(context):
                     return False
                 else:
                     values.append(value)
+            print(values)
             return values
 
     context.remote_cmd = remote_cmd

--- a/environment.py
+++ b/environment.py
@@ -148,7 +148,6 @@ def before_all(context):
                     return False
                 else:
                     values.append(value)
-            print(values)
             return values
 
     context.remote_cmd = remote_cmd
@@ -167,4 +166,5 @@ def after_step(context, step):
         file_logger.info('Step Error Message: %s' % step.error_message)
         if hasattr(context, 'result'):
             file_logger.info('Ansible Output: %s' % context.result)
+            print('Ansible Output: %s' % context.result)
 


### PR DESCRIPTION
Once the step failed, the detailed error is not so obviously unless go to look log file, print the ansible output to make it obviously.

Signed-off-by: Guohua Ouyang gouyang@redhat.com
