### PR TITLE
Adds tests for interrupting rollback

### DIFF
--- a/features/rhelah/rollback_multi_interrupt.feature
+++ b/features/rhelah/rollback_multi_interrupt.feature
@@ -1,0 +1,49 @@
+Feature:  Verifies that the 'atomic host rollback' can be interrupted
+          a single time without error
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        and "all" hosts can be pinged
+
+  Scenario: 1. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 2. Upgrade to latest release
+      Given there is "1" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 3. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 4. Start rollback process and interrupt 10 times
+      Given the rollback interrupt script is present
+        and the original atomic version has been recorded
+       When the rollback interrupt script is run "10" times
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 5. Reboot the system
+      Given the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 6. Complete the rollback
+      Given there is "2" atomic host tree deployed
+       When atomic host rollback is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 7. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 8. Unregister
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"
+

--- a/features/rhelah/rollback_single_interrupt.feature
+++ b/features/rhelah/rollback_single_interrupt.feature
@@ -1,0 +1,49 @@
+Feature:  Verifies that the 'atomic host rollback' can be interrupted
+          a single time without error
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        and "all" hosts can be pinged
+
+  Scenario: 1. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 2. Upgrade to latest release
+      Given there is "1" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 3. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 4. Start rollback process and interrupt 1 times
+      Given the rollback interrupt script is present
+        and the original atomic version has been recorded
+       When the rollback interrupt script is run "1" times
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 5. Reboot the system
+      Given the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should match the original atomic version
+
+  Scenario: 6. Complete the rollback
+      Given there is "2" atomic host tree deployed
+       When atomic host rollback is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 7. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 8. Unregister
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"
+

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -279,3 +279,19 @@ def step_impl(context, num):
                                     module_args='/usr/local/bin/atomic_upgrade_interrupt.sh %s' % num)
 
     assert int_result, "Error while running atomic upgrade interrupt script"
+
+
+@given(u'the rollback interrupt script is present')
+def step_impl(context):
+    stat_result = context.remote_cmd(cmd='stat',
+                                     module_args='path=/usr/local/bin/atomic_rollback_interrupt.sh')
+
+    assert stat_result, "The atomic rollback interrupt script is missing"
+
+
+@when(u'the rollback interrupt script is run "{num}" times')
+def step_impl(context, num):
+    int_result = context.remote_cmd(cmd='command',
+                                    module_args='/usr/local/bin/atomic_rollback_interrupt.sh %s' % num)
+
+    assert int_result, "Error while running atomic rollback interrupt script"


### PR DESCRIPTION
This commit adds steps and feature files that test the interruption of
the 'atomic host rollback' process.

Signed-off-by: Micah Abbott miabbott@redhat.com
