### PR TITLE
Adding tests for multiple rollbacks

### DIFF
--- a/features/rhelah/multiple_rollback.feature
+++ b/features/rhelah/multiple_rollback.feature
@@ -1,0 +1,40 @@
+Feature:  Verifies that 'atomic host rollback' can be used multiple times without error
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        and "all" hosts can be pinged
+
+  Scenario: 1. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 2. Upgrade to latest release
+      Given there is "1" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 3. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 4. Rollback multiple (9) times
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When rollback occurs multiple times
+       Then there is "2" atomic host tree deployed
+        and the current atomic version should match the original atomic version
+
+  Scenario: 5. Rollback once more and reboot
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When atomic host rollback is successful
+        and wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 6. Unregister
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"
+

--- a/features/rhelah/multiple_rollback.feature
+++ b/features/rhelah/multiple_rollback.feature
@@ -20,7 +20,7 @@ Background: Atomic hosts are discovered
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 4. Rollback multiple (9) times
+  Scenario: 4. Rollback multiple (10) times
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When rollback occurs multiple times

--- a/features/rhelah/multiple_rollback_reboot.feature
+++ b/features/rhelah/multiple_rollback_reboot.feature
@@ -1,0 +1,31 @@
+Feature:  Verifies that 'atomic host rollback' followed by a reboot can be used multiple times without error
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        and "all" hosts can be pinged
+
+  Scenario: 1. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 2. Upgrade to latest release
+      Given there is "1" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 3. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 4. Rollback and reboot multiple (9) times
+      Given there is "2" atomic host tree deployed
+       When rollback and reboot occurs multiple times
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 5. Unregister
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"
+

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -215,7 +215,7 @@ def step_impl(context):
         "Unable to retrieve the current atomic version"
     assert current_version != context.original_version, \
         ("The current atomic version %s " % current_version +
-         "did not match the original atomic version " +
+         "erroneously matched the original atomic version " +
          "%s" % context.original_version)
 
 

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -295,3 +295,23 @@ def step_impl(context, num):
                                     module_args='/usr/local/bin/atomic_rollback_interrupt.sh %s' % num)
 
     assert int_result, "Error while running atomic rollback interrupt script"
+
+
+@when(u'rollback and reboot occurs multiple times')
+def step_impl(context):
+    for l in range(9):
+        context.execute_steps(u'''
+            Given the original atomic version has been recorded
+             When atomic host rollback is successful
+              and wait "30" seconds for "all" to reboot
+             Then the current atomic version should not match the original atomic version
+        ''')
+
+
+@when(u'rollback occurs multiple times')
+def step_impl(context):
+    for l in range(9):
+            context.execute_steps(u'''
+                When atomic host rollback is successful
+            ''')
+

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -310,7 +310,7 @@ def step_impl(context):
 
 @when(u'rollback occurs multiple times')
 def step_impl(context):
-    for l in range(9):
+    for l in range(10):
             context.execute_steps(u'''
                 When atomic host rollback is successful
             ''')


### PR DESCRIPTION
This change adds two feature files that test using 'atomic host
rollback' multiple times in succession.  One scenario performs the
rollback then performs a reboot, in a loop.  The other scenario performs
a rollback multiple times, followed by a final rollback + reboot.

The `rhelah.py` step file has also been changed to accomodate these
tests.

Signed-off-by: Micah Abbott miabbott@redhat.com
