### PR TITLE
steps/rhelah.py: tweak version regex

### DIFF
--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -15,7 +15,7 @@ def get_atomic_version(context):
 
     status_re = re.compile(r'^\* '
                            r'(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})'
-                           r' {5}(?P<version>\d+.\d+.\d+(-\d+)?)'
+                           r' {5}(?P<version>\S+)'
                            r' +(?P<id>\w{10})'
                            r' {5}(?P<osname>[\w\-]+)'
                            r' {5}(?P<refspec>[\w:\-/]+)')


### PR DESCRIPTION
It can happen for the version to have 4 components, excluding the dash.
This was causing some feature tests to fail, e.g. upgrade_single_interrupt.
