### PR TITLE
add dummy features always_pass and always_fail

### DIFF
--- a/features/atomic/cluster.feature
+++ b/features/atomic/cluster.feature
@@ -1,11 +1,10 @@
 @kube
 Feature: Atomic cluster smoke test
   Describes minimum functionality for Kubernetes on a multi-node Atomic cluster
-  Cluster is configured using https://github.com/eparis/kubernetes-ansible
+  Cluster is configured using contrib/ansible script in upstream kube repo
 
   Scenario: 1. kubectl API smoke test
        Given "masters" hosts from dynamic inventory
-         and "1" "pods" are running
-         and "2" "minions" are running
-         and "3" "services" are running
-
+         and "0" "pods" are running
+         and "2" "nodes" are running
+         and "1" "services" are running

--- a/features/atomic/cluster.feature
+++ b/features/atomic/cluster.feature
@@ -8,3 +8,4 @@ Feature: Atomic cluster smoke test
          and "0" "pods" are running
          and "2" "nodes" are running
          and "1" "services" are running
+         and nodes are ready

--- a/steps/containers_kube.py
+++ b/steps/containers_kube.py
@@ -56,7 +56,7 @@ def step_impl(context, rpm, image, host):
 @given('"{number}" "{component}" are running')
 def step_impl(context, number, component):
     '''check expected number of components are running
-       where component is pod, service, minion, etc'''
+       where component is pod, service, node, etc'''
     import json
     r = context.remote_cmd('command',
                             module_args='kubectl get %s -o json' % component)

--- a/steps/containers_kube.py
+++ b/steps/containers_kube.py
@@ -90,3 +90,24 @@ def step_impl(context):
     '''check whether container is running'''
     container_id = get_running_container_id(context)
     assert container_id, "There is not a running container"
+
+@given('nodes are ready')
+def step_impl(context):
+    '''check whether the nodes are ready'''
+    import json
+    r = context.remote_cmd('command', module_args='kubectl get nodes -o json')
+
+    if r:
+        for i in r:
+            data = json.loads(i['stdout'])
+            if 'items' not in data:
+                assert True # trivially true
+            else:
+                # We need to find the Ready condition type and check its status.
+                # See docs/admin/node.md#node-condition in kubernetes repo.
+                for node in data['items']:
+                    for condition in node['status']['conditions']:
+                        if condition['type'] == "Ready":
+                            assert condition['status'] == 'True'
+    else:
+        assert False

--- a/steps/containers_kube.py
+++ b/steps/containers_kube.py
@@ -64,7 +64,7 @@ def step_impl(context, number, component):
         for i in r:
             data = json.loads(i['stdout'])
             # terrible hack. must be a better way
-            if data['items']:
+            if 'items' in data:
                 assert len(data['items']) is int(number)
             else:
                 assert int(number) is 0


### PR DESCRIPTION
Because UATFramework is heavily geared towards automation and CI, it is
useful to have dummy features with quickly reproducible results that
can be used to test the overall integration of UATFramework with the
rest of a larger system.

---

Feel free to ignore this PR. I found it useful when testing e.g. integration
with Jenkins, so I thought I'd share. But I can see how it's too trivial to
deserve a place in the codebase.
