### PR TITLE
features/atomic: Add tags in the feature files

### DIFF
--- a/features/atomic/atomic_mount_unmount.feature
+++ b/features/atomic/atomic_mount_unmount.feature
@@ -1,9 +1,11 @@
+@atomic
 Feature: Atomic mount and unmount test for new upgrade tree
     Describes atomic mount/unmount container and image to specified directory
 
 Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
 
+  @env_check
   Scenario: 1. Host provisioned and subscribed
       Given "all" host
        When "all" host is auto-subscribed to "stage"
@@ -46,6 +48,7 @@ Background: Atomic hosts are discovered
   Scenario: 10. remove docker image
        Then remove docker image "busybox"
 
+  @clean_up
   Scenario: 11. Unregister
        Then "all" host is unsubscribed and unregistered
         and subscription status is unknown on "all"

--- a/features/atomic/cluster.feature
+++ b/features/atomic/cluster.feature
@@ -1,3 +1,4 @@
+@kube
 Feature: Atomic cluster smoke test
   Describes minimum functionality for Kubernetes on a multi-node Atomic cluster
   Cluster is configured using https://github.com/eparis/kubernetes-ansible

--- a/features/atomic/docker_pull.feature
+++ b/features/atomic/docker_pull.feature
@@ -1,3 +1,4 @@
+@docker
 Feature: Docker pull
   Run 'docker pull' on list of images
 

--- a/features/atomic/smoketest.feature
+++ b/features/atomic/smoketest.feature
@@ -5,24 +5,28 @@ Feature: Atomic host smoke test
 Background: Atomic hosts are discovered
       Given "cihosts" hosts from dynamic inventory
 
+  @env_check
   Scenario: 1. Host provisioned and subscribed
       Given "cihosts" host
        When "cihosts" host is auto-subscribed to "stage"
        Then subscription status is ok on "cihosts"
         and "1" entitlement is consumed on "cihosts"
 
+  @atomic
   Scenario: 2. Upgrade ostree
       Given active tree version is at "7.0.0" on "cihosts"
        When atomic "upgrade" is run on "cihosts"
        Then wait "60" seconds for "cihosts" to reboot
        Then active tree version is at "7.0.1" on "cihosts"
 
+  @docker
   Scenario: 3. Docker smoke test
       Given "docker" is already installed on "cihosts"
         and "docker" is already running on "cihosts"
        When docker pull "rhel7" on "cihosts"
        Then rpm "bind" is installed in "rhel7" on "cihosts"
 
+  @kube
   Scenario Outline: 4. Kubernetes services
       Given "kubernetes" is already installed on "cihosts"
         and "etcd" is already installed on "cihosts"
@@ -37,9 +41,11 @@ Background: Atomic hosts are discovered
     | kube-proxy              |
     | kubelet                 |
 
+  @kube
   Scenario: 5. kubectl smoke test
        Given "0" pods on "cihosts"
          and "0" services on "cihosts"
 
+  @clean_up
   Scenario: 6. Unregister
        Then "cihosts" host is unsubscribed and unregistered


### PR DESCRIPTION
Add tags in feature files to make it is easier to run a set of
test from different feaeture files based on the tags. Currently
added two types of tags:
env tags: env_check, clean_up
function tags: atomic, kube, docker

For example:

After tags added we can run test for test docker related scenario by following command:

$ behave features/atomic/ --tags=@env_check,@docker,@cleanup
or
$ behave --tags=@env_check,@docker,@cleanup

If this is acceptable will add tags to other feature files.
