### PR TITLE
Updating new tree sanity tests

### DIFF
--- a/features/rhelah/sanity_new_tree.feature
+++ b/features/rhelah/sanity_new_tree.feature
@@ -5,8 +5,8 @@ Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" host
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
+  Scenario: 1. Subscribe to production
+      When "all" host is auto-subscribed to "prod"
        Then subscription status is ok on "all"
         and "1" entitlement is consumed on "all"
 
@@ -21,19 +21,48 @@ Background: Atomic hosts are discovered
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 4. Collect the data about the upgraded system
+  Scenario: 4. Unregister from production
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"
+
+  Scenario: 5. Subscribe to stage
+      When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 6. Gather initial RPM list
+       When "initial" RPM list is collected
+       Then there is a text file with the "initial" RPM list present
+
+  Scenario: 7. 'atomic host upgrade' is successful
+      Given there is "2" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 8. Reboot into the new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 9. Gather upgraded RPM list
+       When "upgraded" RPM list is collected
+       Then there is a text file with the "upgraded" RPM list present
+
+  Scenario: 10. Collect the data about the upgraded system
       Given the data collection script is present
        When the data collection script is run
        Then the data collection output file is present
         and the data collection output files are retrieved
 
-  Scenario: 5. Rollback to the original deployment
+  Scenario: 11. Rollback to the original deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When atomic host rollback is successful
         and wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 6. Unregister
+  Scenario: 12. Unregister
        Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"
+       and subscription status is unknown on "all"
+

--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -266,12 +266,28 @@ def step_impl(context):
     fetch_result = context.remote_cmd(cmd='fetch',
                                       module_args='src=/var/qe/atomic_smoke_output.txt dest=%s/ flat=yes' % jenkins_ws)
 
-    assert fetch_result, "Error retrieving the data collection output file"
+    assert fetch_result, "Error retrieving smoketest output"
 
+    fetch_result = context.remote_cmd(cmd='fetch',
+                                      module_args='src=/var/qe/atomic_version.txt dest=%s/ flat=yes' % jenkins_ws)
+
+    assert fetch_result, "Error retrieving atomic version file"
+    
     fetch_result = context.remote_cmd(cmd='fetch',
                                       module_args='src=/var/qe/atomic_smoke_failed dest=%s/ flat=yes' % jenkins_ws)
 
-    assert fetch_result, "Error retrieving the data collection failure file"
+    assert fetch_result, "Error retrieving smoketest failure output"
+
+    fetch_result = context.remote_cmd(cmd='fetch',
+                                      module_args='src=/var/qe/rpm_initial_list.txt dest=%s/ flat=yes' % jenkins_ws)
+
+    assert fetch_result, "Error retrieving inital RPM list"
+
+    fetch_result = context.remote_cmd(cmd='fetch',
+                                      module_args='src=/var/qe/rpm_upgraded_list.txt dest=%s/ flat=yes' % jenkins_ws)
+
+    assert fetch_result, "Error retrieving upgraded RPM list"
+
 
 
 @given(u'the upgrade interrupt script is present')
@@ -376,3 +392,21 @@ def step_impl(context, mountpoint):
     '''check whether atomic mount point does not exist'''
     filter_result = find_mount_point(context, mountpoint)
     assert filter_result is not None, "Error unmounted container still exists"
+
+
+@when(u'"{list_type}" RPM list is collected')
+def step_impl(context, list_type):
+    rpm_list_res = context.remote_cmd(cmd='shell',
+                                      module_args='rpm -qa | sort > /var/qe/rpm_%s_list.txt' %
+                                                  list_type)
+
+    assert rpm_list_res, "Error retrieving list of installed RPMs"
+
+
+@then(u'there is a text file with the "{list_type}" RPM list present')
+def step_impl(context, list_type):
+    file_res = context.remote_cmd(cmd='stat',
+                                  module_args='path=/var/qe/rpm_%s_list.txt' % list_type)
+
+    assert file_res, "The text file with the RPM list was not present"
+


### PR DESCRIPTION
This change adjusts the steps performed for the sanity test.  Notably,
it causes the system to be subscribed to 'production' and then upgraded
to the latest tree available.  (This makes the assumption that the new
tree that is being tested is in the 'stage' environment.)

Additionally, the list of RPMs is collected after upgrading to the
latest 'released' tree and then after the system has been updated to the
'stage' tree.  This allows us to produce a diff of the list for later
use.

Finally, the necessary changes to the `steps/rhelah.py` file were made
to support the collection and retrieval of the RPM list.

Signed-off-by: Micah Abbott miabbott@redhat.com
