### PR TITLE
Updates to sanity tests

### DIFF
--- a/features/rhelah/sanity_new_qcow.feature
+++ b/features/rhelah/sanity_new_qcow.feature
@@ -9,8 +9,7 @@ Background: Atomic hosts are discovered
   Scenario: 0. Collect the data about the system
       Given the data collection script is present
        When the data collection script is run
-       Then the data collection output file is present
-        and the data collection output files are retrieved
+       Then the generated data files are retrieved
 
   Scenario: 1. Host unprovisioned and 'atomic host upgrade' is used
       Given the original atomic version has been recorded

--- a/features/rhelah/sanity_new_tree.feature
+++ b/features/rhelah/sanity_new_tree.feature
@@ -5,8 +5,8 @@ Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" host
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
+  Scenario: 1. Subscribe to production
+      When "all" host is auto-subscribed to "prod"
        Then subscription status is ok on "all"
         and "1" entitlement is consumed on "all"
 
@@ -21,19 +21,47 @@ Background: Atomic hosts are discovered
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 4. Collect the data about the upgraded system
+  Scenario: 4. Unregister from production
+       Then "all" host is unsubscribed and unregistered
+        and subscription status is unknown on "all"
+
+  Scenario: 5. Subscribe to stage
+      When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        and "1" entitlement is consumed on "all"
+
+  Scenario: 6. Gather initial RPM list
+       When "initial" RPM list is collected
+       Then the text file with the "initial" RPM list is retrieved
+
+  Scenario: 7. 'atomic host upgrade' is successful
+      Given there is "2" atomic host tree deployed
+       When atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 8. Reboot into the new deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When wait "30" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 9. Gather upgraded RPM list
+       When "upgraded" RPM list is collected
+       Then the text file with the "upgraded" RPM list is retrieved
+
+  Scenario: 10. Collect the data about the upgraded system
       Given the data collection script is present
        When the data collection script is run
-       Then the data collection output file is present
-        and the data collection output files are retrieved
+       Then the generated data files are retrieved
 
-  Scenario: 5. Rollback to the original deployment
+  Scenario: 11. Rollback to the original deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When atomic host rollback is successful
         and wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 6. Unregister
+  Scenario: 12. Unregister
        Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"
+       and subscription status is unknown on "all"
+


### PR DESCRIPTION
`features/rhelah/sanity_new_qcow.feature`
`features/rhelah/sanity_new_tree.feature`
`steps/rhelah.py`

The majority of this change affects the steps performed for the 'new
tree' sanity test.  Notably, it causes the system to be subscribed to
'production' and then upgraded to the latest tree available. (This makes
the assumption that the new tree that is being tested is in the 'stage'
environment.)

Additionally, the list of RPMs (and current atomic version) is collected
after upgrading to the latest 'released' tree and then after the system
has been updated to the 'stage' tree. This allows us to produce a diff
of the list for later use.

The 'new qcow' test was updated for some changes to the verbiage used in
the steps.

Finally, the necessary changes to the `steps/rhelah.py` file were made
to support the collection and retrieval of the RPM list and related
files.

Signed-off-by: Micah Abbott miabbott@redhat.com
