### PR TITLE
Add a test case for undeploy unselected deployment

### DIFF
--- a/features/ostree/undeploy_unselected_deployment.feature
+++ b/features/ostree/undeploy_unselected_deployment.feature
@@ -1,0 +1,35 @@
+Feature:  Verifies that the 'atomic host rollback' can be interrupted
+          a single time without error
+
+Background: Atomic hosts are discovered
+      Given "all" hosts from dynamic inventory
+        And "all" hosts can be pinged
+
+  Scenario: 1. Host provisioned and subscribed
+       When "all" host is auto-subscribed to "stage"
+       Then subscription status is ok on "all"
+        And "1" entitlement is consumed on "all"
+
+  Scenario: 2. Upgrade to latest release
+      Given get the number of atomic host tree deployed
+       When confirm atomic host tree to old version
+        And atomic host upgrade is successful
+       Then there is "2" atomic host tree deployed
+
+  Scenario: 3. Reboot into new deployment
+      Given there is "2" atomic host tree deployed
+        And the original atomic version has been recorded
+       When wait "60" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version
+
+  Scenario: 4. Undeploy the new deployment
+      Given there is "2" atomic host tree deployed
+       When confirm atomic host tree to old version
+       Then undeploy the unselected deployment
+       And there is "1" atomic host tree deployed
+       And wait "30" seconds for "all" to reboot
+
+  Scenario: 5. Unregister
+       Then "all" host is unsubscribed and unregistered
+        And subscription status is unknown on "all"
+

--- a/steps/ostree.py
+++ b/steps/ostree.py
@@ -1,0 +1,27 @@
+'''ostree test methods'''
+
+import re
+from behave import *
+
+
+@then(u'undeploy the unselected deployment')
+def step_impl(context):
+    ostree_result = context.remote_cmd(cmd='command',
+                                       module_args='ostree admin status')
+
+    assert ostree_result, "Can not get ostree status"
+
+    ostree_status = ostree_result[0]['stdout']
+    ostree_entry = re.findall(r'.*[\d\w\.]{66}', ostree_status)
+
+    for index, item in enumerate(ostree_entry):
+        if not re.match('\*', item):
+            undep_index = index
+            break
+
+    undeploy_cmd = 'ostree admin undeploy %s' % undep_index
+    undeploy_result = context.remote_cmd(cmd='command',
+                                         module_args=undeploy_cmd)
+
+    assert undeploy_result, "Can not undeploy the %s deployment" % undep_index
+


### PR DESCRIPTION
This is a new test case for undeploy unselected deployment by command "os admin undeploy".

The scenario 2 need the code update from https://github.com/aweiteka/UATFramework/pull/65
