### PR TITLE
Updating successful upgrade step

### DIFF
--- a/steps/rhelah.py
+++ b/steps/rhelah.py
@@ -323,6 +323,9 @@ def step_impl(context):
 
     assert upgrade_result, "Error performing 'atomic host upgrade"
 
+    for r in upgrade_result:
+        assert "No upgrade available" not in r['stdout'], \
+            "Upgrade is unexpectedly not available"
 
 @then(u'the current atomic version should not match the original atomic version')
 def step_impl(context):


### PR DESCRIPTION
The 'successful upgrade' step in `steps/rhelah.py` has been updated to
check for the 'No upgrade available' message that can sometimes occur if
the remote tree is not newer than the existing one.

Signed-off-by: Micah Abbott miabbott@redhat.com
