### PR TITLE
Introduce before_feature and after_feature to the framework

### DIFF
--- a/config/test.cfg.example
+++ b/config/test.cfg.example
@@ -1,3 +1,11 @@
 [default]
 hosts = all
 subman_server = stage
+inventory = dynamic
+target_host = all
+[unique_machine-id]
+target_host = host1,host2
+[rht-registration-from-rubygems]
+target_host = cihosts
+[rht-registration-from-source]
+target_host = cihosts

--- a/config/test.cfg.example
+++ b/config/test.cfg.example
@@ -1,0 +1,3 @@
+[default]
+hosts = all
+subman_server = stage

--- a/env_setup.py
+++ b/env_setup.py
@@ -1,0 +1,43 @@
+"""
+Functions for environment preparition and cleanup.
+"""
+
+
+import behave
+
+
+def host_subscribed_prepare(context):
+    context.execute_steps(u"""
+        When "{hosts}" host is auto-subscribed to "{server}"
+        Then subscription status is ok on "{hosts}"
+         And "1" entitlement is consumed on "{hosts}"
+        """.format(hosts=context.hosts,
+                   server=context.subman_server))
+    print("Register %s hosts to %s" % (context.hosts, context.subman_server))
+
+
+def host_subscribed_cleanup(context):
+    context.execute_steps(u"""
+        Then "{hosts}" host is unsubscribed And unregistered
+         And subscription status is unknown on "all"
+        """.format(hosts=context.hosts))
+    print("Unregister %s hosts" % context.hosts)
+
+
+def ah_upgrade_prepare(context):
+    context.execute_steps(u"""
+        Given get the number of atomic host tree deployed
+         When confirm atomic host tree to old version
+          And atomic host upgrade is successful
+         Then wait "60" seconds for "all" to reboot
+          And there is "2" atomic host tree deployed
+        """)
+
+
+def ah_upgrade_no_reboot_prepare(context):
+    context.execute_steps(u"""
+        Given get the number of atomic host tree deployed
+         When confirm atomic host tree to old version
+          And atomic host upgrade is successful
+          And there is "2" atomic host tree deployed
+        """)

--- a/features/cdk/rht-registration-from-rubygems.feature
+++ b/features/cdk/rht-registration-from-rubygems.feature
@@ -2,8 +2,7 @@ Feature: test vagrant-registration plugin installed from rubygems.org
 
   # set dynamic hosts
   Background: vagrant hosts are discovered
-    Given "cihosts" hosts from dynamic inventory
-    and vagrant plugin is "vagrant-registration"
+    Given vagrant plugin is "vagrant-registration"
 
   #assumes that the slave has the build requirements for a plugin
   Scenario: Install vagrant-registration from rubygems.org

--- a/features/cdk/rht-registration-from-source.feature
+++ b/features/cdk/rht-registration-from-source.feature
@@ -2,8 +2,7 @@ Feature: test vagrant-registration plugin based on source
 
   # set dynamic hosts
   Background: vagrant hosts are discovered
-    Given "cihosts" hosts from dynamic inventory
-    and vagrant plugin is "vagrant-registration"
+    Given vagrant plugin is "vagrant-registration"
 
   #assumes that the slave has the build requirements for a plugin
   Scenario: Get and build vagrant-registration plugin

--- a/features/rhelah/atomic/atomic_images.feature
+++ b/features/rhelah/atomic/atomic_images.feature
@@ -3,7 +3,7 @@ Feature: Atomic images test for new upgrade tree
     Describes listing locally installed images and removing all dangling images on your system
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
+      Given "all" hosts can be pinged
 
   Scenario: 1. Pull latest image from repository
       Given List all locally installed container images

--- a/features/rhelah/atomic/atomic_images.feature
+++ b/features/rhelah/atomic/atomic_images.feature
@@ -1,41 +1,23 @@
-@atomic
+@atomic @host_subscribed @ah_upgrade
 Feature: Atomic images test for new upgrade tree
     Describes listing locally installed images and removing all dangling images on your system
 
 Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
 
-  @env_check
-  Scenario: 1. Host provisioned and subscribed
-      Given "all" host
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. 'atomic host upgrade' is successful
-      Given there is "1" atomic host tree deployed
-       When atomic host upgrade is successful
-       Then wait "30" seconds for "all" to reboot
-       Then there is "2" atomic host tree deployed
-
-  Scenario: 3. Pull latest image from repository
+  Scenario: 1. Pull latest image from repository
       Given List all locally installed container images
        When atomic update latest "centos" from repository
        Then Check whether "centos" is installed
 
-  Scenario: 4. Build a new image from Dockerfile
+  Scenario: 2. Build a new image from Dockerfile
        When docker build an image from "https://raw.githubusercontent.com/projectatomic/atomic/master/tests/test-images/Dockerfile.1"
        Then Check whether dangling images exist
 
-  Scenario: 5. Remove dangling images
+  Scenario: 3. Remove dangling images
        When Remove all dangling images
        Then Check whether dangling images do not exist
 
-  Scenario: 6. Remove specified image
+  Scenario: 4. Remove specified image
        When Remove "centos" from system
        Then Check whether "centos" is removed from system
-
-  @clean_up
-  Scenario: 7. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"

--- a/features/rhelah/atomic/atomic_info.feature
+++ b/features/rhelah/atomic/atomic_info.feature
@@ -1,40 +1,22 @@
-@atomic
+@atomic @host_subscribed @ah_upgrade
 Feature: Atomic info test for new upgrade tree
     Describes display label information about a local and remote image
 
 Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
 
-  @env_check
-  Scenario: 1. Host provisioned and subscribed
-      Given "all" host
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. 'atomic host upgrade' is successful
-      Given there is "1" atomic host tree deployed
-       When atomic host upgrade is successful
-       Then wait "30" seconds for "all" to reboot
-       Then there is "2" atomic host tree deployed
-
-  Scenario: 3. Build a new image with new tag from Dockerfile
+  Scenario: 1. Build a new image with new tag from Dockerfile
        When docker build an image with tag "scratch_test" from "https://raw.githubusercontent.com/projectatomic/atomic/master/tests/test-images/Dockerfile.2"
        Then Check whether "scratch_test" is installed
 
-  Scenario: 4. Display label information about a local image
+  Scenario: 2. Display label information about a local image
        When Display LABEL information about an image "scratch_test"
        Then Check LABEL "Name: atomic-test-2" information for an image
 
-  Scenario: 5. Display label information about a remote image
+  Scenario: 3. Display label information about a remote image
        When Display LABEL information about a "remote" image "rhel7"
        Then Check LABEL "Vendor: Red Hat, Inc." information for an image
 
-  Scenario: 6. Remove specified image
+  Scenario: 4. Remove specified image
        When Remove "scratch_test" from system
        Then Check whether "scratch_test" is removed from system
-
-  @clean_up
-  Scenario: 7. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"

--- a/features/rhelah/atomic/atomic_info.feature
+++ b/features/rhelah/atomic/atomic_info.feature
@@ -3,7 +3,7 @@ Feature: Atomic info test for new upgrade tree
     Describes display label information about a local and remote image
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
+      Given "all" hosts can be pinged
 
   Scenario: 1. Build a new image with new tag from Dockerfile
        When docker build an image with tag "scratch_test" from "https://raw.githubusercontent.com/projectatomic/atomic/master/tests/test-images/Dockerfile.2"

--- a/features/rhelah/atomic/atomic_mount_unmount.feature
+++ b/features/rhelah/atomic/atomic_mount_unmount.feature
@@ -1,54 +1,36 @@
-@atomic
+@atomic @host_subscribed @ah_upgrade
 Feature: Atomic mount and unmount test for new upgrade tree
     Describes atomic mount/unmount container and image to specified directory
 
 Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
 
-  @env_check
-  Scenario: 1. Host provisioned and subscribed
-      Given "all" host
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. 'atomic host upgrade' is successful
-      Given there is "1" atomic host tree deployed
-       When atomic host upgrade is successful
-       Then wait "30" seconds for "all" to reboot
-       Then there is "2" atomic host tree deployed
-
-  Scenario: 3. docker pull image
+  Scenario: 1. docker pull image
       Given "docker" is already running on "all"
        When docker pull "busybox"
 
-  Scenario: 4. mount image to a specified directory
+  Scenario: 2. mount image to a specified directory
        When atomic mount "image" to a specified "/mnt"
        Then check whether atomic mount point "/var/mnt" exists
 
-  Scenario: 5. unmount image previously mounted
+  Scenario: 3. unmount image previously mounted
        When atomic unmount image from previous "/mnt"
        Then check whether atomic mount point "/var/mnt" does not exist
 
-  Scenario: 6. docker run busybox with detach mode
+  Scenario: 4. docker run busybox with detach mode
        When docker run "busybox" detach mode with "/usr/bin/top -b"
        Then check whether there is a running container
 
-  Scenario: 7. mount running container to a specified directory
+  Scenario: 5. mount running container to a specified directory
        When atomic mount "container" to a specified "/mnt"
        Then check whether atomic mount point "/var/mnt" exists
 
-  Scenario: 8. unmount container previously mounted
+  Scenario: 6. unmount container previously mounted
        When atomic unmount container from previous "/mnt"
        Then check whether atomic mount point "/var/mnt" does not exist
 
-  Scenario: 9. atomic stop previous running container
+  Scenario: 7. atomic stop previous running container
        When atomic stop container
 
-  Scenario: 10. remove docker image
+  Scenario: 8. remove docker image
        Then remove docker image "busybox"
-
-  @clean_up
-  Scenario: 11. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"

--- a/features/rhelah/atomic/atomic_mount_unmount.feature
+++ b/features/rhelah/atomic/atomic_mount_unmount.feature
@@ -3,7 +3,7 @@ Feature: Atomic mount and unmount test for new upgrade tree
     Describes atomic mount/unmount container and image to specified directory
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
+      Given "all" hosts can be pinged
 
   Scenario: 1. docker pull image
       Given "docker" is already running on "all"

--- a/features/rhelah/atomic/multiple_rollback.feature
+++ b/features/rhelah/atomic/multiple_rollback.feature
@@ -1,41 +1,26 @@
+@host_subscribed @ah_upgrade_no_reboot
 Feature:  Verifies that 'atomic host rollback' can be used multiple times without error
 
 Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" hosts can be pinged
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. Upgrade to latest release
-      Given get the number of atomic host tree deployed
-       When confirm atomic host tree to old version
-        And atomic host upgrade is successful
-       Then there is "2" atomic host tree deployed
-
-  Scenario: 3. Reboot into new deployment
+  Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 4. Rollback multiple (10) times
+  Scenario: 2. Rollback multiple (10) times
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When rollback occurs multiple times
        Then there is "2" atomic host tree deployed
         and the current atomic version should match the original atomic version
 
-  Scenario: 5. Rollback once more and reboot
+  Scenario: 3. Rollback once more and reboot
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When atomic host rollback is successful
         and wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
-
-  Scenario: 6. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"
-

--- a/features/rhelah/atomic/multiple_rollback.feature
+++ b/features/rhelah/atomic/multiple_rollback.feature
@@ -2,8 +2,7 @@
 Feature:  Verifies that 'atomic host rollback' can be used multiple times without error
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" hosts can be pinged
+      Given "all" hosts can be pinged
 
   Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed

--- a/features/rhelah/atomic/multiple_rollback_reboot.feature
+++ b/features/rhelah/atomic/multiple_rollback_reboot.feature
@@ -1,32 +1,17 @@
+@host_subscribed @ah_upgrade_no_reboot
 Feature:  Verifies that 'atomic host rollback' followed by a reboot can be used multiple times without error
 
 Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" hosts can be pinged
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. Upgrade to latest release
-      Given get the number of atomic host tree deployed
-       When confirm atomic host tree to old version
-        And atomic host upgrade is successful
-       Then there is "2" atomic host tree deployed
-
-  Scenario: 3. Reboot into new deployment
+  Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 4. Rollback and reboot multiple (9) times
+  Scenario: 2. Rollback and reboot multiple (9) times
       Given there is "2" atomic host tree deployed
        When rollback and reboot occurs multiple times
        Then there is "2" atomic host tree deployed
-
-  Scenario: 5. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"
-

--- a/features/rhelah/atomic/multiple_rollback_reboot.feature
+++ b/features/rhelah/atomic/multiple_rollback_reboot.feature
@@ -2,8 +2,7 @@
 Feature:  Verifies that 'atomic host rollback' followed by a reboot can be used multiple times without error
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" hosts can be pinged
+      Given "all" hosts can be pinged
 
   Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed

--- a/features/rhelah/atomic/no_refs_to_cdn_stage.feature
+++ b/features/rhelah/atomic/no_refs_to_cdn_stage.feature
@@ -1,8 +1,7 @@
 Feature: Verify that there are no references to the Stage environment on Atomic Host after upgrade to the latest ostree
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
 Scenario: 0. register to the stage environment, upgrade to the latest OSTree version, reboot and check whether there are no references to the Stage environment
        When "all" host is auto-subscribed to "prod"

--- a/features/rhelah/atomic/rollback_multi_interrupt.feature
+++ b/features/rhelah/atomic/rollback_multi_interrupt.feature
@@ -3,8 +3,7 @@ Feature:  Verifies that the 'atomic host rollback' can be interrupted
           a single time without error
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" hosts can be pinged
+      Given "all" hosts can be pinged
 
   Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed

--- a/features/rhelah/atomic/rollback_multi_interrupt.feature
+++ b/features/rhelah/atomic/rollback_multi_interrupt.feature
@@ -1,3 +1,4 @@
+@host_subscribed @ah_upgrade_no_reboot
 Feature:  Verifies that the 'atomic host rollback' can be interrupted
           a single time without error
 
@@ -5,46 +6,30 @@ Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" hosts can be pinged
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. Upgrade to latest release
-      Given get the number of atomic host tree deployed
-       When confirm atomic host tree to old version
-        And atomic host upgrade is successful
-       Then there is "2" atomic host tree deployed
-
-  Scenario: 3. Reboot into new deployment
+  Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 4. Start rollback process and interrupt 10 times
+  Scenario: 2. Start rollback process and interrupt 10 times
       Given the rollback interrupt script is present
         and the original atomic version has been recorded
        When the rollback interrupt script is run "10" times
        Then the current atomic version should match the original atomic version
 
-  Scenario: 5. Reboot the system
+  Scenario: 3. Reboot the system
       Given the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should match the original atomic version
 
-  Scenario: 6. Complete the rollback
+  Scenario: 4. Complete the rollback
       Given there is "2" atomic host tree deployed
        When atomic host rollback is successful
        Then there is "2" atomic host tree deployed
 
-  Scenario: 7. Reboot into new deployment
+  Scenario: 5. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
-
-  Scenario: 8. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"
-

--- a/features/rhelah/atomic/rollback_single_interrupt.feature
+++ b/features/rhelah/atomic/rollback_single_interrupt.feature
@@ -3,8 +3,7 @@ Feature:  Verifies that the 'atomic host rollback' can be interrupted
           a single time without error
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" hosts can be pinged
+      Given "all" hosts can be pinged
 
   Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed

--- a/features/rhelah/atomic/rollback_single_interrupt.feature
+++ b/features/rhelah/atomic/rollback_single_interrupt.feature
@@ -1,3 +1,4 @@
+@host_subscribed @ah_upgrade_no_reboot
 Feature:  Verifies that the 'atomic host rollback' can be interrupted
           a single time without error
 
@@ -5,46 +6,30 @@ Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" hosts can be pinged
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. Upgrade to latest release
-      Given get the number of atomic host tree deployed
-       When confirm atomic host tree to old version
-        And atomic host upgrade is successful
-       Then there is "2" atomic host tree deployed
-
-  Scenario: 3. Reboot into new deployment
+  Scenario: 1. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
 
-  Scenario: 4. Start rollback process and interrupt 1 times
+  Scenario: 2. Start rollback process and interrupt 1 times
       Given the rollback interrupt script is present
         and the original atomic version has been recorded
        When the rollback interrupt script is run "1" times
        Then the current atomic version should match the original atomic version
 
-  Scenario: 5. Reboot the system
+  Scenario: 3. Reboot the system
       Given the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should match the original atomic version
 
-  Scenario: 6. Complete the rollback
+  Scenario: 4. Complete the rollback
       Given there is "2" atomic host tree deployed
        When atomic host rollback is successful
        Then there is "2" atomic host tree deployed
 
-  Scenario: 7. Reboot into new deployment
+  Scenario: 5. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
-
-  Scenario: 8. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"
-

--- a/features/rhelah/atomic/sanity_new_qcow.feature
+++ b/features/rhelah/atomic/sanity_new_qcow.feature
@@ -3,8 +3,7 @@ Feature: Atomic host sanity test for new QCOW images
     QCOW image install.
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. Collect the data about the system
       Given the data collection script is present

--- a/features/rhelah/atomic/sanity_new_tree.feature
+++ b/features/rhelah/atomic/sanity_new_tree.feature
@@ -2,8 +2,7 @@ Feature: Atomic host sanity test for new upgrade tree
     Describes tests for upgrade/rollback to/from new ostree
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 1. Subscribe to production
       When "all" host is auto-subscribed to "prod"

--- a/features/rhelah/atomic/tree_gpg_signed.feature
+++ b/features/rhelah/atomic/tree_gpg_signed.feature
@@ -1,8 +1,7 @@
 Feature: Check if the current tree is signed with Red Hat's release key 2
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. import Red Hat's release key 2 and verify it's public fingerprint 
        When import Red Hat's release key 2 to the superuser's keyring succeeds

--- a/features/rhelah/atomic/unique_machine-id.feature
+++ b/features/rhelah/atomic/unique_machine-id.feature
@@ -1,10 +1,6 @@
 Feature: Atomic unique machine_id test
     Tests whether /etc/machine_id is unique between two RHEL Atomic Hosts deployments
 
-Background: Atomic hosts are discovered
-      Given "host1" hosts from dynamic inventory
-	and "host2" hosts from dynamic inventory
-
   Scenario: 0. /etc/machine-id is unique with each instance of rhelah
        Given machine-id on "host1" is recorded
         and machine-id on "host2" is recorded

--- a/features/rhelah/atomic/upgrade_multi_interrupt.feature
+++ b/features/rhelah/atomic/upgrade_multi_interrupt.feature
@@ -1,3 +1,4 @@
+@host_subscribed
 Feature:  Verifies that the 'atomic host upgrade' can be interrupted
           multiple times without error
 
@@ -5,33 +6,24 @@ Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" hosts can be pinged
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. Start upgrade process and interrupt 7 times
+  Scenario: 1. Start upgrade process and interrupt 7 times
       Given the upgrade interrupt script is present
         and the original atomic version has been recorded
        When the upgrade interrupt script is run "7" times
        Then the current atomic version should match the original atomic version
 
-  Scenario: 3. Reboot the system
+  Scenario: 2. Reboot the system
       Given the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should match the original atomic version
 
-  Scenario: 4. Complete the upgrade
+  Scenario: 3. Complete the upgrade
       Given there is "1" atomic host tree deployed
        When atomic host upgrade is successful
        Then there is "2" atomic host tree deployed
 
-  Scenario: 5. Reboot into new deployment
+  Scenario: 4. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
-
-  Scenario: 6. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"

--- a/features/rhelah/atomic/upgrade_multi_interrupt.feature
+++ b/features/rhelah/atomic/upgrade_multi_interrupt.feature
@@ -3,8 +3,7 @@ Feature:  Verifies that the 'atomic host upgrade' can be interrupted
           multiple times without error
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" hosts can be pinged
+      Given "all" hosts can be pinged
 
   Scenario: 1. Start upgrade process and interrupt 7 times
       Given the upgrade interrupt script is present

--- a/features/rhelah/atomic/upgrade_single_interrupt.feature
+++ b/features/rhelah/atomic/upgrade_single_interrupt.feature
@@ -1,3 +1,4 @@
+@host_subscribed
 Feature:  Verifies that the 'atomic host upgrade' can be interrupted
           a single time without error
 
@@ -5,33 +6,24 @@ Background: Atomic hosts are discovered
       Given "all" hosts from dynamic inventory
         and "all" hosts can be pinged
 
-  Scenario: 1. Host provisioned and subscribed
-       When "all" host is auto-subscribed to "stage"
-       Then subscription status is ok on "all"
-        and "1" entitlement is consumed on "all"
-
-  Scenario: 2. Start upgrade process and interrupt 1 times
+  Scenario: 1. Start upgrade process and interrupt 1 times
       Given the upgrade interrupt script is present
         and the original atomic version has been recorded
        When the upgrade interrupt script is run "1" times
        Then the current atomic version should match the original atomic version
 
-  Scenario: 3. Reboot the system
+  Scenario: 2. Reboot the system
       Given the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should match the original atomic version
 
-  Scenario: 4. Complete the upgrade
+  Scenario: 3. Complete the upgrade
       Given there is "1" atomic host tree deployed
        When atomic host upgrade is successful
        Then there is "2" atomic host tree deployed
 
-  Scenario: 5. Reboot into new deployment
+  Scenario: 4. Reboot into new deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When wait "30" seconds for "all" to reboot
        Then the current atomic version should not match the original atomic version
-
-  Scenario: 6. Unregister
-       Then "all" host is unsubscribed and unregistered
-        and subscription status is unknown on "all"

--- a/features/rhelah/atomic/upgrade_single_interrupt.feature
+++ b/features/rhelah/atomic/upgrade_single_interrupt.feature
@@ -3,8 +3,7 @@ Feature:  Verifies that the 'atomic host upgrade' can be interrupted
           a single time without error
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" hosts can be pinged
+      Given "all" hosts can be pinged
 
   Scenario: 1. Start upgrade process and interrupt 1 times
       Given the upgrade interrupt script is present

--- a/features/subman/subman_bad_password.feature
+++ b/features/subman/subman_bad_password.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (bad password)
     Tests whether subscription-manager fails to register when provided with bad password
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has failed
        Given cloud-init on "all" host is running

--- a/features/subman/subman_bad_pool_list.feature
+++ b/features/subman/subman_bad_pool_list.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (bad pool-id)
     Tests whether subscription-manager fails to attach non-existent pool-id
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has failed
        Given cloud-init on "all" host is running

--- a/features/subman/subman_bad_pool_scalar.feature
+++ b/features/subman/subman_bad_pool_scalar.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (pool-id not a list)
     Tests whether subscription-manager fails to attach pool-id specified as a scalar
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has failed
        Given cloud-init on "all" host is running

--- a/features/subman/subman_bad_repoid.feature
+++ b/features/subman/subman_bad_repoid.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (non-existent repo)
     Tests whether subscription-manager doesn't crash when trying to add non-existent repo
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has been run successfully
        Given cloud-init on "all" host is running

--- a/features/subman/subman_bad_subscription_keys.feature
+++ b/features/subman/subman_bad_subscription_keys.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (bad subscription ke
     Tests whether subscription-manager fails to complete when incorrect subscription keys are provided
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has failed
        Given cloud-init on "all" host is running

--- a/features/subman/subman_bad_username.feature
+++ b/features/subman/subman_bad_username.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (bad username)
     Tests whether subscription-manager fails to register when provided with bad username
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has failed
        Given cloud-init on "all" host is running

--- a/features/subman/subman_mixed_pool_list.feature
+++ b/features/subman/subman_mixed_pool_list.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (mixed pool-id)
     Tests whether subscription-manager completes successfully when provided mix of existent and non-existent pools
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has been run successfully
        Given cloud-init on "all" host is running

--- a/features/subman/subman_ok.feature
+++ b/features/subman/subman_ok.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test
     Tests whether subscription-manager uses provided credentials to register to the CDN, attaches pools, enables/disables provided repoids
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has been run successfully
        Given cloud-init on "all" host is running

--- a/features/subman/subman_reenable_redisable_repoids.feature
+++ b/features/subman/subman_reenable_redisable_repoids.feature
@@ -2,8 +2,7 @@ Feature: Atomic cloud-init subscription-manager plugin test (re-enable/re-disabl
     Tests whether subscription-manager successfully finishes when attempting to enable/disable already enabled/disabled repos and issues informational message
 
 Background: Atomic hosts are discovered
-      Given "all" hosts from dynamic inventory
-        and "all" host
+      Given "all" host
 
   Scenario: 0. subscription-manager plugin has been run successfully
        Given cloud-init on "all" host is running


### PR DESCRIPTION
This pullreq aimed to summarize the common setup and cleanup functions for each features and make it separated from the real test steps. This will help to reduce the duplicate code in features.

And also have to make it easier to switch the target host between dynamic and static.
