### PR TITLE
features.rhelah: avoid using absolute path of command

### DIFF
--- a/features/rhelah/atomic/atomic_mount_unmount.feature
+++ b/features/rhelah/atomic/atomic_mount_unmount.feature
@@ -18,7 +18,7 @@ Background: Atomic hosts are discovered
        Then check whether atomic mount point "/var/mnt" does not exist
 
   Scenario: 4. docker run busybox with detach mode
-       When docker run "busybox" detach mode with "/usr/bin/top -b"
+       When docker run "busybox" detach mode with "top -b"
        Then check whether there is a running container
 
   Scenario: 5. mount running container to a specified directory


### PR DESCRIPTION
If the path of command is changed in images, this feature will be failed
to run, so it had better to avoid using absolute path of command for
command line in docker run.

Signed-off-by: Alex Jia ajia@redhat.com
