### PR TITLE
Add test cases for atomic diff

### DIFF
--- a/features/rhelah/atomic/sanity_test.feature
+++ b/features/rhelah/atomic/sanity_test.feature
@@ -5,8 +5,8 @@ Feature: Atomic host sanity test
 Background: Atomic hosts are discovered
       Given "all" hosts can be pinged
 
-  @pull_image
-  Scenario: 1. Pull latest image from repository
+  @pull_centos_image
+  Scenario: 1. Pull latest centos image from repository
       Given List all locally installed container images
        When atomic update latest "centos" from repository
        Then Check whether "centos" is installed
@@ -21,80 +21,126 @@ Background: Atomic hosts are discovered
        When atomic unmount image from previous "/mnt"
        Then check whether atomic mount point "/var/mnt" does not exist
 
+  @compare_the_same_rpm_image
+  Scenario: 4. Compare the RPMs in 2 same images
+       When Compare the RPMs between "centos" and "centos"
+       Then check whether "/sysroot/tmp" does not exist
+
   @run_container_in_bg
-  Scenario: 4. docker run busybox with detach mode
+  Scenario: 5. docker run centos with detach mode
        When docker run "centos" detach mode with "top -b"
        Then check whether there is a running container
 
   @mount_container_to_path
-  Scenario: 5. mount running container to a specified directory
+  Scenario: 6. mount running container to a specified directory
        When atomic mount "container" to a specified "/mnt"
        Then check whether atomic mount point "/var/mnt" exists
 
   @unmount_container_from_path
-  Scenario: 6. unmount container previously mounted
+  Scenario: 7. unmount container previously mounted
        When atomic unmount container from previous "/mnt"
        Then check whether atomic mount point "/var/mnt" does not exist
 
   @stop_container
-  Scenario: 7. atomic stop previous running container
+  Scenario: 8. atomic stop previous running container
        When atomic stop container
 
   @build_dangling_image
-  Scenario: 8. Build a new image from Dockerfile
+  Scenario: 9. Build a new image from Dockerfile
        When docker build an image from local "Dockerfile.1"
        Then Check whether dangling images exist
 
   @remove_dangling_image
-  Scenario: 9. Remove dangling images
+  Scenario: 10. Remove dangling images
        When Remove all dangling images
        Then Check whether dangling images do not exist
 
   @build_label_image
-  Scenario: 10. Build a new image from Dockerfile
+  Scenario: 11. Build a new image from Dockerfile
        When docker build an image with tag "centos_label" from local "Dockerfile.1"
        Then Check whether "centos_label" is installed
 
   @check_image_name_version
-  Scenario: 11. Display image label of name version release
+  Scenario: 12. Display image label of name version release
        When Display "centos_label" "atomic-test-1" of name version release
 
   @read_label_install_in_image
-  Scenario: 12. Read the LABEL INSTALL field in the container image
+  Scenario: 13. Read the LABEL INSTALL field in the container image
        When Read the LABEL INSTALL "I am the install label." field in the container "centos_label"
 
+  @build_apache_image
+  Scenario: 14. Build a apache image from Dockerfile
+       When docker build an image with tag "centos/apache" from local "Dockerfile.3"
+       Then Check whether "centos/apache" is installed
+
+  @compare_the_different_rpm_image
+  Scenario: 15. Compare the RPMs in 2 different images
+       When Compare the RPMs with "-nr" between "centos" and "centos/apache"
+       Then check whether "/sysroot/tmp" does not exist
+
+  @pull_busybox_image
+  Scenario: 16. Pull latest image from repository
+      Given List all locally installed container images
+       When atomic update latest "busybox" from repository
+       Then Check whether "busybox" is installed
+
+  @compare_the_image_not_rpm_based
+  Scenario: 17. Compare the RPMs in 2 no RPMs images
+       When Compare the RPMs between "busybox" and "busybox" are "no" RPMs based
+       Then check whether "/sysroot/tmp" does not exist
+
+  @compare_the_image_with_arguments_1
+  Scenario: 18. Compare the RPMs with -nr --json options
+       When Compare the RPMs with "-nr --json" between "centos" and "centos/apache"
+       Then check whether "/sysroot/tmp" does not exist
+
+  @compare_the_image_with_arguments_2
+  Scenario: 19. Compare the RPMs with -v --names-only options
+       When Compare the RPMs with "-v --names-only" between "centos" and "centos/apache"
+       Then check whether "/sysroot/tmp" does not exist
+
   @build_info_image
-  Scenario: 13. Build a new image with new tag from Dockerfile
+  Scenario: 20. Build a new image with new tag from Dockerfile
        When docker build an image with tag "scratch_test" from local "Dockerfile.2"
        Then Check whether "scratch_test" is installed
 
   @check_local_image_label
-  Scenario: 14. Display label information about a local image
+  Scenario: 21. Display label information about a local image
        When Display LABEL information about an image "scratch_test"
        Then Check LABEL "Name: atomic-test-2" information for an image
 
   @check_remote_image_label
-  Scenario: 15. Display label information about a remote image
+  Scenario: 22. Display label information about a remote image
        When Display LABEL information about a "remote" image "rhel7"
        Then Check LABEL "Vendor: Red Hat, Inc." information for an image
 
   @remove_built_info_image
-  Scenario: 16. Remove scratch_test image
+  Scenario: 23. Remove scratch_test image
        When Remove "scratch_test" from system
        Then Check whether "scratch_test" is removed from system
 
   @remove_built_label_image
-  Scenario: 17. Remove centos_label image
+  Scenario: 24. Remove centos_label image
        When Remove "centos_label" from system
        Then Check whether "centos_label" is removed from system
 
-  @remove_pulled_image
-  Scenario: 18. Remove centos image
+  @remove_pulled_busybox_image
+  Scenario: 25. Remove busybox image
+       Then remove docker image "busybox"
+         and Check whether "busybox" is removed from system
+
+  @remove_built_apache_image
+  Scenario: 26. Remove apache image
+       Then remove docker image "centos/apache"
+         and Check whether "centos/apache" is removed from system
+
+  @remove_pulled_centos_image
+  Scenario: 27. Remove centos image
        Then remove docker image "centos"
          and Check whether "centos" is removed from system
 
   @rollback_host
-  Scenario: 19. Rollback to the original deployment
+  Scenario: 28. Rollback to the original deployment
       Given there is "2" atomic host tree deployed
         and the original atomic version has been recorded
        When atomic host rollback is successful

--- a/resources/docker/Dockerfile.3
+++ b/resources/docker/Dockerfile.3
@@ -1,0 +1,8 @@
+FROM centos
+
+RUN yum install -y httpd
+RUN echo "Apache HTTPD" >> /var/www/html/index.html
+
+EXPOSE 80
+
+CMD ["/usr/sbin/httpd", "-D", "FOREGROUND"]


### PR DESCRIPTION
```
[root@83eddb43628a UATFramework]# behave features/rhelah/atomic/sanity_test.feature
Feature: Atomic host sanity test # features/rhelah/atomic/sanity_test.feature:2
  Describes the basic 'atomic host' command test
  Background: Atomic hosts are discovered  # features/rhelah/atomic/sanity_test.feature:5

  @pull_centos_image
  Scenario: 1. Pull latest centos image from repository  # features/rhelah/atomic/sanity_test.feature:9
    Given "all" hosts can be pinged                      # steps/common.py:201 1.382s
    Given List all locally installed container images    # steps/rhelah.py:533 0.632s
    When atomic update latest "centos" from repository   # steps/rhelah.py:499 47.274s
    Then Check whether "centos" is installed             # steps/rhelah.py:508 0.636s

  @mount_image_to_path
  Scenario: 2. mount image to a specified directory         # features/rhelah/atomic/sanity_test.feature:15
    Given "all" hosts can be pinged                         # steps/common.py:201 0.220s
    When atomic mount "image" to a specified "/mnt"         # steps/rhelah.py:455 2.474s
    Then check whether atomic mount point "/var/mnt" exists # steps/rhelah.py:475 0.235s

  @unmount_image_from_path
  Scenario: 3. unmount image previously mounted                     # features/rhelah/atomic/sanity_test.feature:20
    Given "all" hosts can be pinged                                 # steps/common.py:201 0.225s
    When atomic unmount image from previous "/mnt"                  # steps/rhelah.py:482 1.134s
    Then check whether atomic mount point "/var/mnt" does not exist # steps/rhelah.py:492 0.236s

  @compare_the_same_rpm_image
  Scenario: 4. Compare the RPMs in 2 same images        # features/rhelah/atomic/sanity_test.feature:25
    Given "all" hosts can be pinged                     # steps/common.py:201 0.224s
    When Compare the RPMs between "centos" and "centos" # steps/rhelah.py:654 4.553s
    Then check whether "/sysroot/tmp" does not exist    # steps/rhelah.py:492 0.236s

  @run_container_in_bg
  Scenario: 5. docker run centos with detach mode      # features/rhelah/atomic/sanity_test.feature:30
    Given "all" hosts can be pinged                    # steps/common.py:201 0.226s
    When docker run "centos" detach mode with "top -b" # steps/docker.py:65 1.521s
    Then check whether there is a running container    # steps/docker.py:71 0.266s

  @mount_container_to_path
  Scenario: 6. mount running container to a specified directory  # features/rhelah/atomic/sanity_test.feature:35
    Given "all" hosts can be pinged                              # steps/common.py:201 0.227s
    When atomic mount "container" to a specified "/mnt"          # steps/rhelah.py:455 4.018s
    Then check whether atomic mount point "/var/mnt" exists      # steps/rhelah.py:475 0.236s

  @unmount_container_from_path
  Scenario: 7. unmount container previously mounted                 # features/rhelah/atomic/sanity_test.feature:40
    Given "all" hosts can be pinged                                 # steps/common.py:201 0.223s
    When atomic unmount container from previous "/mnt"              # steps/rhelah.py:482 1.233s
    Then check whether atomic mount point "/var/mnt" does not exist # steps/rhelah.py:492 0.235s

  @stop_container
  Scenario: 8. atomic stop previous running container  # features/rhelah/atomic/sanity_test.feature:45
    Given "all" hosts can be pinged                    # steps/common.py:201 0.225s
    When atomic stop container                         # steps/rhelah.py:446 2.041s

  @build_dangling_image
  Scenario: 9. Build a new image from Dockerfile         # features/rhelah/atomic/sanity_test.feature:49
    Given "all" hosts can be pinged                      # steps/common.py:201 0.227s
    When docker build an image from local "Dockerfile.1" # steps/docker.py:77 18.910s
    Then Check whether dangling images exist             # steps/rhelah.py:540 0.636s

  @remove_dangling_image
  Scenario: 10. Remove dangling images              # features/rhelah/atomic/sanity_test.feature:54
    Given "all" hosts can be pinged                 # steps/common.py:201 0.224s
    When Remove all dangling images                 # steps/rhelah.py:549 1.055s
    Then Check whether dangling images do not exist # steps/rhelah.py:556 0.636s

  @build_label_image
  Scenario: 11. Build a new image from Dockerfile                                # features/rhelah/atomic/sanity_test.feature:59
    Given "all" hosts can be pinged                                              # steps/common.py:201 0.224s
    When docker build an image with tag "centos_label" from local "Dockerfile.1" # steps/docker.py:77 18.172s
    Then Check whether "centos_label" is installed                               # steps/rhelah.py:508 0.639s

  @check_image_name_version
  Scenario: 12. Display image label of name version release             # features/rhelah/atomic/sanity_test.feature:64
    Given "all" hosts can be pinged                                     # steps/common.py:201 0.224s
    When Display "centos_label" "atomic-test-1" of name version release # steps/rhelah.py:619 0.657s

  @read_label_install_in_image
  Scenario: 13. Read the LABEL INSTALL field in the container image                             # features/rhelah/atomic/sanity_test.feature:68
    Given "all" hosts can be pinged                                                             # steps/common.py:201 0.226s
    When Read the LABEL INSTALL "I am the install label." field in the container "centos_label" # steps/rhelah.py:640 2.439s

  @build_apache_image
  Scenario: 14. Build a apache image from Dockerfile                              # features/rhelah/atomic/sanity_test.feature:72
    Given "all" hosts can be pinged                                               # steps/common.py:201 0.226s
    When docker build an image with tag "centos/apache" from local "Dockerfile.3" # steps/docker.py:77 49.413s
    Then Check whether "centos/apache" is installed                               # steps/rhelah.py:508 0.638s

  @compare_the_different_rpm_image
  Scenario: 15. Compare the RPMs in 2 different images                    # features/rhelah/atomic/sanity_test.feature:77
    Given "all" hosts can be pinged                                       # steps/common.py:201 0.224s
    When Compare the RPMs with "-nr" between "centos" and "centos/apache" # steps/rhelah.py:654 3.604s
    Then check whether "/sysroot/tmp" does not exist                      # steps/rhelah.py:492 0.237s

  @pull_busybox_image
  Scenario: 16. Pull latest image from repository       # features/rhelah/atomic/sanity_test.feature:82
    Given "all" hosts can be pinged                     # steps/common.py:201 0.224s
    Given List all locally installed container images   # steps/rhelah.py:533 0.649s
    When atomic update latest "busybox" from repository # steps/rhelah.py:499 24.316s
    Then Check whether "busybox" is installed           # steps/rhelah.py:508 0.637s

  @compare_the_image_not_rpm_based
  Scenario: 17. Compare the RPMs in 2 no RPMs images                          # features/rhelah/atomic/sanity_test.feature:88
    Given "all" hosts can be pinged                                           # steps/common.py:201 0.224s
    When Compare the RPMs between "busybox" and "busybox" are "no" RPMs based # steps/rhelah.py:654 3.636s
    Then check whether "/sysroot/tmp" does not exist                          # steps/rhelah.py:492 0.237s

  @compare_the_image_with_arguments_1
  Scenario: 18. Compare the RPMs with -nr --json options                         # features/rhelah/atomic/sanity_test.feature:93
    Given "all" hosts can be pinged                                              # steps/common.py:201 0.223s
    When Compare the RPMs with "-nr --json" between "centos" and "centos/apache" # steps/rhelah.py:654 3.660s
    Then check whether "/sysroot/tmp" does not exist                             # steps/rhelah.py:492 0.236s

  @compare_the_image_with_arguments_2
  Scenario: 19. Compare the RPMs with -v --names-only options                         # features/rhelah/atomic/sanity_test.feature:98
    Given "all" hosts can be pinged                                                   # steps/common.py:201 0.224s
    When Compare the RPMs with "-v --names-only" between "centos" and "centos/apache" # steps/rhelah.py:654 4.151s
    Then check whether "/sysroot/tmp" does not exist                                  # steps/rhelah.py:492 0.235s

  @build_info_image
  Scenario: 20. Build a new image with new tag from Dockerfile                   # features/rhelah/atomic/sanity_test.feature:103
    Given "all" hosts can be pinged                                              # steps/common.py:201 0.223s
    When docker build an image with tag "scratch_test" from local "Dockerfile.2" # steps/docker.py:77 4.637s
    Then Check whether "scratch_test" is installed                               # steps/rhelah.py:508 0.644s

  @check_local_image_label
  Scenario: 21. Display label information about a local image       # features/rhelah/atomic/sanity_test.feature:108
    Given "all" hosts can be pinged                                 # steps/common.py:201 0.227s
    When Display LABEL information about an image "scratch_test"    # steps/rhelah.py:603 0.640s
    Then Check LABEL "Name: atomic-test-2" information for an image # steps/rhelah.py:612 0.000s

  @check_remote_image_label
  Scenario: 22. Display label information about a remote image        # features/rhelah/atomic/sanity_test.feature:113
    Given "all" hosts can be pinged                                   # steps/common.py:201 0.223s
    When Display LABEL information about a "remote" image "rhel7"     # steps/rhelah.py:603 15.470s
    Then Check LABEL "Vendor: Red Hat, Inc." information for an image # steps/rhelah.py:612 0.000s

  @remove_built_info_image
  Scenario: 23. Remove scratch_test image                    # features/rhelah/atomic/sanity_test.feature:118
    Given "all" hosts can be pinged                          # steps/common.py:201 0.225s
    When Remove "scratch_test" from system                   # steps/rhelah.py:517 0.862s
    Then Check whether "scratch_test" is removed from system # steps/rhelah.py:524 0.638s

  @remove_built_label_image
  Scenario: 24. Remove centos_label image                    # features/rhelah/atomic/sanity_test.feature:123
    Given "all" hosts can be pinged                          # steps/common.py:201 0.224s
    When Remove "centos_label" from system                   # steps/rhelah.py:517 1.048s
    Then Check whether "centos_label" is removed from system # steps/rhelah.py:524 0.634s

  @remove_pulled_busybox_image
  Scenario: 25. Remove busybox image                   # features/rhelah/atomic/sanity_test.feature:128
    Given "all" hosts can be pinged                    # steps/common.py:201 0.224s
    Then remove docker image "busybox"                 # steps/docker.py:45 0.352s
    And Check whether "busybox" is removed from system # steps/rhelah.py:524 0.651s

  @remove_built_apache_image
  Scenario: 26. Remove apache image                          # features/rhelah/atomic/sanity_test.feature:133
    Given "all" hosts can be pinged                          # steps/common.py:201 0.225s
    Then remove docker image "centos/apache"                 # steps/docker.py:45 0.437s
    And Check whether "centos/apache" is removed from system # steps/rhelah.py:524 0.634s

  @remove_pulled_centos_image
  Scenario: 27. Remove centos image                   # features/rhelah/atomic/sanity_test.feature:138
    Given "all" hosts can be pinged                   # steps/common.py:201 0.225s
    Then remove docker image "centos"                 # steps/docker.py:45 0.510s
    And Check whether "centos" is removed from system # steps/rhelah.py:524 0.641s

1 feature passed, 0 failed, 0 skipped
27 scenarios passed, 0 failed, 0 skipped
80 steps passed, 0 failed, 0 skipped, 0 undefined
Took 3m56.772s
```
