### PR TITLE
Pin 'ansible' to pre-2.0 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 behave
-ansible==1.9.4
+ansible<2.0
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 behave
-ansible
+ansible==1.9.4
 jinja2


### PR DESCRIPTION
With the release of Ansible 2.0, the API was entirely re-written.  What
was once a simple import of a single Ansible module has become a bit
more complex.  See the following:

http://docs.ansible.com/ansible/developing_api.html#python-api-2-0

In the short term, it is easiest to select a version earlier than 2.0 to keep 
things humming.  Longer term, we should probably look at adapting the 
framework to the new API.

Signed-off-by: Micah Abbott miabbott@redhat.com
