### PR TITLE
Atomic mount test

### DIFF
--- a/features/rhelah/atomic/atomic_mount.feature
+++ b/features/rhelah/atomic/atomic_mount.feature
@@ -1,0 +1,108 @@
+@atomic @host_subscribed @ah_upgrade
+Feature: Atomic mount sanity test
+    Describes the basic 'atomic mount' command test
+
+Background: Atomic hosts are discovered
+      Given "all" hosts can be pinged
+
+  @pull_busybox_image
+  Scenario: 1. Pull latest busybox image from repository
+       When atomic update latest "busybox" from repository
+       Then check whether "busybox" is installed
+
+  @mount_image_without_option
+  Scenario: 2. mount image to a specified directory
+       When atomic mount image "busybox" to a specified "/mnt"
+       Then check whether mount option "/var/mnt" exists
+
+  @unmount_without_option_image
+  Scenario: 3. unmount busybox image previously mounted
+       When atomic unmount image from previous "/mnt"
+       Then check whether mount option "/var/mnt" does not exist
+
+  @mount_image_with_live_option
+  Scenario: 4. mount live image to a specified directory
+       When atomic mount image "busybox" with "--live" to a specified "/mnt"
+
+  @pull_rhel7_image
+  Scenario: 5. Pull latest rhel7 image from repository
+       When atomic update latest "registry.access.redhat.com/rhel7" from repository
+       Then check whether "rhel7" is installed
+
+  @run_rhel7_in_bg
+  Scenario: 6. docker run rhel7 with detach mode
+       When docker run "registry.access.redhat.com/rhel7" in detach mode with "mount_test" "top -b"
+       Then find latest created container by name "mount_test"
+
+  @mount_container_without_option
+  Scenario: 7. mount running container by name to a specified directory
+       When atomic mount container "mount_test" to a specified "/mnt"
+       Then check whether mount option "/var/mnt" exists
+        and check "mount_test" "/var/mnt"
+
+  @pull_rsyslog_image
+  Scenario: 8. Pull latest rhel7/rsyslog image from repository
+       When atomic update latest "registry.access.redhat.com/rhel7/rsyslog" from repository
+       Then check whether "rsyslog" is installed
+
+  @run_rsyslog1_with_command
+  Scenario: 9. docker run rhel7/rsyslog with detach mode and attach previous mount point into it
+       When docker run "registry.access.redhat.com/rhel7/rsyslog" "--volume /var/mnt:/mnt" in detach mode "false" with "C1" "ls /mnt" and ignore error "true"
+       Then check if "Permission denied" is in result of docker run
+
+  @unmount_without_option_container
+  Scenario: 10. unmount container previously mounted
+       When atomic unmount container from previous "/mnt"
+       Then check whether mount option "/var/mnt" does not exist
+
+  @mount_container_with_live_option
+  Scenario: 11. mount running container with live option
+       When atomic mount container "mount_test" with "--live" to a specified "/mnt"
+       Then check whether mount option "/var/mnt" exists
+        and check "mount_test" "/var/mnt" "--live"
+
+  @run_rsyslog2_with_command
+  Scenario: 12. docker run rhel7/rsyslog with detach mode and attach previous mount point into it
+       When docker run "registry.access.redhat.com/rhel7/rsyslog" "--volume /var/mnt:/mnt" in detach mode "false" with "C2" "ls /mnt" and ignore error "true"
+       Then check if "Permission denied" is in result of docker run
+
+  @unmount_live_container
+  Scenario: 13. unmount live container previously mounted
+       When atomic unmount container from previous "/mnt"
+       Then check whether mount option "/var/mnt" does not exist
+
+  @mount_container_with_shared_option
+  Scenario: 14. mount running container with shared option
+       When atomic mount container "mount_test" with "--shared" to a specified "/mnt"
+       Then check whether mount option "/var/mnt" exists
+        and check "mount_test" "/var/mnt" "--shared"
+
+  @run_rsyslog3_with_command
+  Scenario: 15. docker run rhel7/rsyslog with detach mode and attach previous mount point into it
+       When docker run "registry.access.redhat.com/rhel7/rsyslog" "--volume /var/mnt:/mnt" in detach mode "false" with "C3" "ls -Z /mnt" and ignore error "true"
+       Then check if "system_u:object_r:usr_t:s0" is in result of docker run
+
+  @unmount_shared_container
+  Scenario: 16. unmount shared container previously mounted
+       When atomic unmount container from previous "/mnt"
+       Then check whether mount option "/var/mnt" does not exist
+
+  @stop_container
+  Scenario: 17. atomic stop previous running container
+       When atomic stop container "mount_test"
+
+  @remove_all_containers
+  Scenario: 18. Remove all of containers
+       When docker remove all of containers
+
+  @remove_all_images
+  Scenario: 19. Remove all of containers
+       When docker remove all of images
+
+  @rollback_host
+  Scenario: 20. Rollback to the original deployment
+      Given there is "2" atomic host tree deployed
+        and the original atomic version has been recorded
+       When atomic host rollback is successful
+        and wait "60" seconds for "all" to reboot
+       Then the current atomic version should not match the original atomic version

--- a/features/rhelah/atomic/sanity_test.feature
+++ b/features/rhelah/atomic/sanity_test.feature
@@ -13,12 +13,12 @@ Background: Atomic hosts are discovered
   @mount_image_to_path
   Scenario: 2. mount image to a specified directory
        When atomic mount image "centos" to a specified "/mnt"
-       Then check whether atomic mount point "/var/mnt" exists
+       Then check whether mount option "/var/mnt" exists
 
   @unmount_image_from_path
   Scenario: 3. unmount image previously mounted
        When atomic unmount image from previous "/mnt"
-       Then check whether atomic mount point "/var/mnt" does not exist
+       Then check whether mount option "/var/mnt" does not exist
 
   @compare_the_same_rpm_image
   Scenario: 4. Compare the RPMs in 2 same images
@@ -33,12 +33,12 @@ Background: Atomic hosts are discovered
   @mount_container_to_path
   Scenario: 6. mount running container by name to a specified directory
        When atomic mount container "mount_test" to a specified "/mnt"
-       Then check whether atomic mount point "/var/mnt" exists
+       Then check whether mount option "/var/mnt" exists
 
   @unmount_container_from_path
   Scenario: 7. unmount container previously mounted
        When atomic unmount container from previous "/mnt"
-       Then check whether atomic mount point "/var/mnt" does not exist
+       Then check whether mount option "/var/mnt" does not exist
 
   @stop_container
   Scenario: 8. atomic stop previous running container
@@ -130,17 +130,17 @@ Background: Atomic hosts are discovered
   @remove_pulled_busybox_image
   Scenario: 26. Remove busybox image
        Then remove docker image "busybox"
-         and Check whether "busybox" is removed from system
+        and Check whether "busybox" is removed from system
 
   @remove_built_apache_image
   Scenario: 27. Remove apache image
        Then remove docker image "centos/apache"
-         and Check whether "centos/apache" is removed from system
+        and Check whether "centos/apache" is removed from system
 
   @remove_pulled_centos_image
   Scenario: 28. Remove centos image
        Then remove docker image "centos"
-         and Check whether "centos" is removed from system
+        and Check whether "centos" is removed from system
 
   @rollback_host
   Scenario: 29. Rollback to the original deployment

--- a/steps/common.py
+++ b/steps/common.py
@@ -29,6 +29,10 @@ def exec_service_cmd(context, action, service_name, host=None):
 
     return result[0]['stdout']
 
+def string_to_bool(context, string):
+    '''convert string to bool'''
+    bool_dict = {'false':False, 'False': False, 'true':True, 'True': True}
+    return bool_dict[string]
 
 @given(u'get the services from configure file')
 def step_impl(context):


### PR DESCRIPTION
The PR is used for covering new command option for atomic mount.

``` shell
$ behave features/rhelah/atomic/atomic_mount.feature 
Feature: Atomic mount sanity test # features/rhelah/atomic/atomic_mount.feature:2
  Describes the basic 'atomic mount' command test
  Background: Atomic hosts are discovered  # features/rhelah/atomic/atomic_mount.feature:5

  @pull_busybox_image
  Scenario: 1. Pull latest busybox image from repository  # features/rhelah/atomic/atomic_mount.feature:9
    Given "all" hosts can be pinged                       # steps/common.py:205 1.415s
    When atomic update latest "busybox" from repository   # steps/rhelah.py:542 13.897s
    Then Check whether "busybox" is installed             # steps/rhelah.py:551 0.903s

  @mount_image_without_option
  Scenario: 2. mount image to a specified directory         # features/rhelah/atomic/atomic_mount.feature:14
    Given "all" hosts can be pinged                         # steps/common.py:205 0.223s
    When atomic mount image "busybox" to a specified "/mnt" # steps/rhelah.py:486 2.730s
    Then check whether atomic mount point "/var/mnt" exists # steps/rhelah.py:518 0.237s

  @unmount_without_option_image
  Scenario: 3. unmount busybox image previously mounted             # features/rhelah/atomic/atomic_mount.feature:19
    Given "all" hosts can be pinged                                 # steps/common.py:205 0.223s
    When atomic unmount image from previous "/mnt"                  # steps/rhelah.py:525 1.340s
    Then check whether atomic mount point "/var/mnt" does not exist # steps/rhelah.py:535 0.250s

  @mount_image_with_live_option
  Scenario: 4. mount live image to a specified directory                  # features/rhelah/atomic/atomic_mount.feature:24
    Given "all" hosts can be pinged                                       # steps/common.py:205 0.241s
    When atomic mount image "busybox" with "--live" to a specified "/mnt" # steps/rhelah.py:486 2.232s

  @pull_rhel7_image
  Scenario: 5. Pull latest rhel7 image from repository                           # features/rhelah/atomic/atomic_mount.feature:28
    Given "all" hosts can be pinged                                              # steps/common.py:205 0.232s
    When atomic update latest "registry.access.redhat.com/rhel7" from repository # steps/rhelah.py:542 13.974s
    Then Check whether "rhel7" is installed                                      # steps/rhelah.py:551 0.907s

  @run_rhel7_in_bg
  Scenario: 6. docker run rhel7 with detach mode                                                 # features/rhelah/atomic/atomic_mount.feature:33
    Given "all" hosts can be pinged                                                              # steps/common.py:205 0.236s
    When docker run "registry.access.redhat.com/rhel7" in detach mode with "mount_test" "top -b" # steps/docker.py:73 1.734s
    Then find latest created container by name "mount_test"                                      # steps/docker.py:103 0.288s

  @mount_container_without_option
  Scenario: 7. mount running container by name to a specified directory  # features/rhelah/atomic/atomic_mount.feature:38
    Given "all" hosts can be pinged                                      # steps/common.py:205 0.225s
    When atomic mount container "mount_test" to a specified "/mnt"       # steps/rhelah.py:507 6.819s
    Then check whether atomic mount point "/var/mnt" exists              # steps/rhelah.py:518 0.232s
    And Check "mount_test" "/var/mnt"                                    # steps/rhelah.py:766 0.457s

  @pull_rsyslog_image
  Scenario: 8. Pull latest rhel7/rsyslog image from repository                           # features/rhelah/atomic/atomic_mount.feature:44
    Given "all" hosts can be pinged                                                      # steps/common.py:205 0.219s
    When atomic update latest "registry.access.redhat.com/rhel7/rsyslog" from repository # steps/rhelah.py:542 15.142s
    Then Check whether "rsyslog" is installed                                            # steps/rhelah.py:551 0.920s

  @run_rsyslog1_with_command
  Scenario: 9. docker run rhel7/rsyslog with detach mode and attach previous mount point into it                                                           # features/rhelah/atomic/atomic_mount.feature:49
    Given "all" hosts can be pinged                                                                                                                        # steps/common.py:205 0.225s
    When docker run "registry.access.redhat.com/rhel7/rsyslog" "--volume /var/mnt:/mnt" in detach mode "false" with "C1" "ls /mnt" and ignore error "true" # steps/docker.py:73 1.961s
    Then check if "Permission denied" is in result of docker run                                                                                           # steps/docker.py:109 0.000s

  @unmount_without_option_container
  Scenario: 10. unmount container previously mounted                # features/rhelah/atomic/atomic_mount.feature:54
    Given "all" hosts can be pinged                                 # steps/common.py:205 0.241s
    When atomic unmount container from previous "/mnt"              # steps/rhelah.py:525 1.318s
    Then check whether atomic mount point "/var/mnt" does not exist # steps/rhelah.py:535 0.251s

  @mount_container_with_live_option
  Scenario: 11. mount running container with live option                         # features/rhelah/atomic/atomic_mount.feature:59
    Given "all" hosts can be pinged                                              # steps/common.py:205 0.221s
    When atomic mount container "mount_test" with "--live" to a specified "/mnt" # steps/rhelah.py:507 1.413s
    Then check whether atomic mount point "/var/mnt" exists                      # steps/rhelah.py:518 0.247s
    And Check "mount_test" "/var/mnt" "--live"                                   # steps/rhelah.py:766 0.496s

  @run_rsyslog2_with_command
  Scenario: 12. docker run rhel7/rsyslog with detach mode and attach previous mount point into it                                                          # features/rhelah/atomic/atomic_mount.feature:65
    Given "all" hosts can be pinged                                                                                                                        # steps/common.py:205 0.233s
    When docker run "registry.access.redhat.com/rhel7/rsyslog" "--volume /var/mnt:/mnt" in detach mode "false" with "C2" "ls /mnt" and ignore error "true" # steps/docker.py:73 1.703s
    Then check if "Permission denied" is in result of docker run                                                                                           # steps/docker.py:109 0.000s

  @unmount_live_container
  Scenario: 13. unmount live container previously mounted           # features/rhelah/atomic/atomic_mount.feature:70
    Given "all" hosts can be pinged                                 # steps/common.py:205 0.237s
    When atomic unmount container from previous "/mnt"              # steps/rhelah.py:525 1.241s
    Then check whether atomic mount point "/var/mnt" does not exist # steps/rhelah.py:535 0.239s

  @mount_container_with_shared_option
  Scenario: 14. mount running container with shared option                         # features/rhelah/atomic/atomic_mount.feature:75
    Given "all" hosts can be pinged                                                # steps/common.py:205 0.221s
    When atomic mount container "mount_test" with "--shared" to a specified "/mnt" # steps/rhelah.py:507 5.317s
    Then check whether atomic mount point "/var/mnt" exists                        # steps/rhelah.py:518 0.231s
    And Check "mount_test" "/var/mnt" "--shared"                                   # steps/rhelah.py:766 0.490s

  @run_rsyslog3_with_command
  Scenario: 15. docker run rhel7/rsyslog with detach mode and attach previous mount point into it                                                             # features/rhelah/atomic/atomic_mount.feature:81
    Given "all" hosts can be pinged                                                                                                                           # steps/common.py:205 0.231s
    When docker run "registry.access.redhat.com/rhel7/rsyslog" "--volume /var/mnt:/mnt" in detach mode "false" with "C3" "ls -Z /mnt" and ignore error "true" # steps/docker.py:73 2.212s
    Then check if "system_u:object_r:usr_t:s0" is in result of docker run                                                                                     # steps/docker.py:109 0.000s

  @unmount_shared_container
  Scenario: 16. unmount shared container previously mounted         # features/rhelah/atomic/atomic_mount.feature:86
    Given "all" hosts can be pinged                                 # steps/common.py:205 0.219s
    When atomic unmount container from previous "/mnt"              # steps/rhelah.py:525 1.281s
    Then check whether atomic mount point "/var/mnt" does not exist # steps/rhelah.py:535 0.240s

  @stop_container
  Scenario: 17. atomic stop previous running container  # features/rhelah/atomic/atomic_mount.feature:91
    Given "all" hosts can be pinged                     # steps/common.py:205 0.223s
    When atomic stop container "mount_test"             # steps/rhelah.py:472 2.212s

  @remove_all_containers
  Scenario: 18. Remove all of containers  # features/rhelah/atomic/atomic_mount.feature:95
    Given "all" hosts can be pinged       # steps/common.py:205 0.223s
    When docker remove all of containers  # steps/docker.py:147 0.393s

  @remove_all_images
  Scenario: 19. Remove all of containers  # features/rhelah/atomic/atomic_mount.feature:99
    Given "all" hosts can be pinged       # steps/common.py:205 0.237s
    When docker remove all of images      # steps/docker.py:141 0.346s

  @rollback_host
  Scenario: 20. Rollback to the original deployment                              # features/rhelah/atomic/atomic_mount.feature:103
    Given "all" hosts can be pinged                                              # steps/common.py:205 0.219s
    Given there is "2" atomic host tree deployed                                 # steps/rhelah.py:250 0.850s
    And the original atomic version has been recorded                            # steps/rhelah.py:308 0.841s
    When atomic host rollback is successful                                      # steps/rhelah.py:367 6.520s
    And wait "60" seconds for "all" to reboot                                    # steps/rhelah.py:169 61.989s
    Then the current atomic version should not match the original atomic version # steps/rhelah.py:356 1.046s

1 feature passed, 0 failed, 0 skipped
20 scenarios passed, 0 failed, 0 skipped
62 steps passed, 0 failed, 0 skipped, 0 undefined
Took 2m40.640s
```
