### PR TITLE
Atomic host unlock test

### DIFF
--- a/features/rhelah/atomic/atomic_host_unlock.feature
+++ b/features/rhelah/atomic/atomic_host_unlock.feature
@@ -1,0 +1,58 @@
+@atomic @host_subscribed @ah_upgrade
+Feature: Atomic host unlock sanity test
+    Describes the basic 'atomic host unlock' command test
+
+Background: Atomic hosts are discovered
+      Given "all" hosts can be pinged
+
+  @change_to_development_mode
+  Scenario: 1. change atomic host to development mode
+      When switch atomic host to development mode
+      When create file "/usr/unlock_dev_test"
+      Then check unlock status "Unlocked: development" exists
+       and Check whether mount option "overlay /usr overlay rw" exists
+       and run command "shell ls /usr/unlock_dev_test"
+
+  @reboot_host_then_check_dev_mode
+  Scenario: 2. reboot atomic host then check development mode
+      When wait "60" seconds for "all" to reboot
+      Then check unlock status "Unlocked: development" does not exists "true"
+       and check whether mount option "overlay /usr overlay rw" does not exist
+       and run command "shell ls /usr/unlock_test" ignore error "true"
+
+  @change_to_hotfix_mode
+  Scenario: 3. change atomic host to hotfix mode
+      When switch atomic host to "hotfix" mode
+      When create file "/usr/unlock_hotfix_test"
+      Then check unlock status "Unlocked: hotfix" exists
+       and Check whether mount option "overlay /usr overlay rw" exists
+       and run command "shell ls /usr/unlock_hotfix_test"
+
+  @reboot_host_then_check_hotfix_mode
+  Scenario: 4. reboot atomic host then check hotfix mode
+      When wait "60" seconds for "all" to reboot
+      Then check unlock status "Unlocked: hotfix" exists
+       and check whether mount option "overlay /usr overlay rw" exists
+       and run command "shell ls /usr/unlock_hotfix_test"
+
+  @rollback_host_after_hotfix_mode
+  Scenario: 5. Rollback to the original deployment
+      When atomic host rollback is successful
+       and wait "60" seconds for "all" to reboot
+      Then check whether mount option "overlay /usr overlay rw" does not exist
+       and run command "shell ls /usr/unlock_test" ignore error "true"
+
+  @rollback_host_to_hotfix_mode
+  Scenario: 6. Rollback to the hotfix deployment
+      When atomic host rollback is successful
+       and wait "60" seconds for "all" to reboot
+      Then check unlock status "Unlocked: hotfix" exists
+       and Check whether mount option "overlay /usr overlay rw" exists
+       and run command "shell ls /usr/unlock_hotfix_test"
+
+  @rollback_host
+    Scenario: 7. Rollback to the original deployment
+      When atomic host rollback is successful
+       and wait "60" seconds for "all" to reboot
+      Then check whether mount option "overlay /usr overlay rw" does not exist
+       and run command "shell ls /usr/unlock_test" ignore error "true"

--- a/steps/common.py
+++ b/steps/common.py
@@ -119,12 +119,12 @@ def step_impl(context, status):
 @given(u'"{host}" hosts from dynamic inventory')
 def step_impl(context, host):
     context.inventory = "dynamic"
-    context.target_host = host 
+    context.target_host = host
 
 @given(u'"{host}" hosts from static inventory')
 def step_impl(context, host):
     context.inventory = "static"
-    context.target_host = host 
+    context.target_host = host
 
 @given(u'"{rpm}" is already installed on "{host}"')
 def step_impl(context, rpm, host):
@@ -144,7 +144,7 @@ def step_impl(context, rpm):
     '''Install RPM on host but fail if not already installed'''
     context.execute_steps(u"""
     given "{package_name}" is already installed on "{host}"
-    """.format(package_name=rpm,host=context.target_host))
+    """.format(package_name=rpm, host=context.target_host))
 
 @given(u'"{rpms}" are already installed on "{host}"')
 def step_impl(context, rpms, host):
@@ -164,7 +164,7 @@ def step_impl(context, rpms):
     '''Install RPM on host but fail if not already installed'''
     context.execute_steps(u"""
     "given {package_names}" are already installed on "{host}"
-    """.format(package_names=rpms,host=context.target_host))
+    """.format(package_names=rpms, host=context.target_host))
 
 @given(u'"{unit}" is already running on "{host}"')
 def step_impl(context, unit, host):
@@ -210,10 +210,12 @@ def step(context, host):
     host: a host from the ansible inventory file'''
     assert context.remote_cmd('ping', host)
 
+@then('run command "{cmd}"')
 @given('run command "{cmd}" on "{host}"')
 @when('run command "{cmd}" on "{host}"')
 @then('run command "{cmd}" on "{host}"')
-def step(context, cmd, host):
+@then('run command "{cmd}" ignore error "{ignore_rc}"')
+def step(context, cmd, host=None, ignore_rc='false'):
     '''Run an Ansible module on a host directly from scenario
 
     cmd: a module name plus arguments
@@ -221,6 +223,7 @@ def step(context, cmd, host):
          or...
          <module> <param>
     host: a host from the inventory file'''
+    ignore_rc = string_to_bool(context, ignore_rc)
     module, args = None, None
     if ' ' in cmd:
         # we only split on the first space to get the module name
@@ -230,6 +233,7 @@ def step(context, cmd, host):
         module = cmd
     assert context.remote_cmd(module,
                               host,
+                              ignore_rc=ignore_rc,
                               module_args=args)
 
 @when('checkout the git repo "{repo}" on "{host}"')

--- a/steps/ostree.py
+++ b/steps/ostree.py
@@ -4,14 +4,19 @@ import re
 from behave import *
 
 
-@then(u'undeploy the unselected deployment')
-def step_impl(context):
+def get_ostree_admin_status(context):
+    '''get ostree admin status'''
     ostree_result = context.remote_cmd(cmd='command',
                                        module_args='ostree admin status')
+    assert ostree_result, "Can not get status result"
+    result = ostree_result[0]['stdout']
+    assert result, "Can not get deployments"
+    return result
 
-    assert ostree_result, "Can not get ostree status"
 
-    ostree_status = ostree_result[0]['stdout']
+@then(u'undeploy the unselected deployment')
+def step_impl(context):
+    ostree_status = get_ostree_admin_status(context)
     ostree_entry = re.findall(r'.*[\d\w\.]{66}', ostree_status)
 
     for index, item in enumerate(ostree_entry):


### PR DESCRIPTION
This PR is based on #90, please review #90 firstly, and then I will rebase the PR once #90 is merged.

steps/common.py: run command ignore error
steps/rhelah.py: update mount related functions and add atomic host unlock function
steps/ostree.py: define get_ostree_admin_status()

features/rhelah/atomic/atomic_mount.feature,
features/rhelah/atomic/sanity_test.feature: update mount related testing

features/rhelah/atomic/atomic_host_unlock.feature: add testing for atomic host unlock

``` shell
$ behave features/rhelah/atomic/atomic_host_unlock.feature
Feature: Atomic host unlock sanity test # features/rhelah/atomic/atomic_host_unlock.feature:2
  Describes the basic 'atomic host unlock' command test
  Background: Atomic hosts are discovered  # features/rhelah/atomic/atomic_host_unlock.feature:5

  @change_to_development_mode
  Scenario: 1. change atomic host to development mode               # features/rhelah/atomic/atomic_host_unlock.feature:9
    Given "all" hosts can be pinged                                 # steps/common.py:205 1.666s
    When Switch atomic host to development mode                     # steps/rhelah.py:793 0.917s
    When Create file "/usr/unlock_dev_test"                         # steps/rhelah.py:812 0.253s
    Then Check unlock status "Unlocked: development" exists         # steps/rhelah.py:801 0.162s
    And Check whether mount option "overlay /usr overlay rw" exists # steps/rhelah.py:519 0.144s
    And run command "shell ls /usr/unlock_dev_test"                 # steps/common.py:213 0.134s

  @reboot_host_then_check_dev_mode
  Scenario: 2. reboot atomic host then check development mode               # features/rhelah/atomic/atomic_host_unlock.feature:17
    Given "all" hosts can be pinged                                         # steps/common.py:205 0.142s
    When wait "60" seconds for "all" to reboot                              # steps/rhelah.py:170 62.078s
    Then Check unlock status "Unlocked: development" does not exists "true" # steps/rhelah.py:801 0.338s
    And check whether mount option "overlay /usr overlay rw" does not exist # steps/rhelah.py:536 0.241s
    And run command "shell ls /usr/unlock_test" ignore error "true"         # steps/common.py:213 0.258s

  @change_to_hotfix_mode
  Scenario: 3. change atomic host to hotfix mode                    # features/rhelah/atomic/atomic_host_unlock.feature:24
    Given "all" hosts can be pinged                                 # steps/common.py:205 0.228s
    When Switch atomic host to "hotfix" mode                        # steps/rhelah.py:793 13.135s
    When Create file "/usr/unlock_hotfix_test"                      # steps/rhelah.py:812 0.244s
    Then Check unlock status "Unlocked: hotfix" exists              # steps/rhelah.py:801 0.152s
    And Check whether mount option "overlay /usr overlay rw" exists # steps/rhelah.py:519 0.149s
    And run command "shell ls /usr/unlock_hotfix_test"              # steps/common.py:213 0.145s

  @reboot_host_then_check_hotfix_mode
  Scenario: 4. reboot atomic host then check hotfix mode            # features/rhelah/atomic/atomic_host_unlock.feature:32
    Given "all" hosts can be pinged                                 # steps/common.py:205 0.126s
    When wait "60" seconds for "all" to reboot                      # steps/rhelah.py:170 61.797s
    Then Check unlock status "Unlocked: hotfix" exists              # steps/rhelah.py:801 0.219s
    And check whether mount option "overlay /usr overlay rw" exists # steps/rhelah.py:519 0.149s
    And run command "shell ls /usr/unlock_hotfix_test"              # steps/common.py:213 0.152s

  @rollback_host_after_hotfix_mode
  Scenario: 5. Rollback to the original deployment                           # features/rhelah/atomic/atomic_host_unlock.feature:39
    Given "all" hosts can be pinged                                          # steps/common.py:205 0.135s
    When atomic host rollback is successful                                  # steps/rhelah.py:368 5.421s
    And wait "60" seconds for "all" to reboot                                # steps/rhelah.py:170 62.022s
    Then check whether mount option "overlay /usr overlay rw" does not exist # steps/rhelah.py:536 0.237s
    And run command "shell ls /usr/unlock_test" ignore error "true"          # steps/common.py:213 0.262s

  @rollback_host_to_hotfix_mode
  Scenario: 6. Rollback to the hotfix deployment                    # features/rhelah/atomic/atomic_host_unlock.feature:46
    Given "all" hosts can be pinged                                 # steps/common.py:205 0.261s
    When atomic host rollback is successful                         # steps/rhelah.py:368 5.489s
    And wait "60" seconds for "all" to reboot                       # steps/rhelah.py:170 61.858s
    Then Check unlock status "Unlocked: hotfix" exists              # steps/rhelah.py:801 0.210s
    And Check whether mount option "overlay /usr overlay rw" exists # steps/rhelah.py:519 1.138s
    And run command "shell ls /usr/unlock_hotfix_test"              # steps/common.py:213 0.147s

  @rollback_host
  Scenario: 7. Rollback to the original deployment                           # features/rhelah/atomic/atomic_host_unlock.feature:54
    Given "all" hosts can be pinged                                          # steps/common.py:205 0.135s
    When atomic host rollback is successful                                  # steps/rhelah.py:368 4.925s
    And wait "60" seconds for "all" to reboot                                # steps/rhelah.py:170 62.082s
    Then check whether mount option "overlay /usr overlay rw" does not exist # steps/rhelah.py:536 0.237s
    And run command "shell ls /usr/unlock_test" ignore error "true"          # steps/common.py:213 0.232s

1 feature passed, 0 failed, 0 skipped
7 scenarios passed, 0 failed, 0 skipped
38 steps passed, 0 failed, 0 skipped, 0 undefined
Took 5m47.620s
```
